### PR TITLE
fix(container-terminal): component crash when ws error before term init

### DIFF
--- a/src/components/Modals/KubeCtl/index.jsx
+++ b/src/components/Modals/KubeCtl/index.jsx
@@ -35,7 +35,7 @@ export default class KubeCtlModal extends React.Component {
   terminalRef = React.createRef()
 
   componentDidMount() {
-    this.store.getKSWebSocketUrl()
+    this.store.fetchKubeCtl()
   }
 
   onTipsToggle = () => {

--- a/src/stores/terminal.js
+++ b/src/stores/terminal.js
@@ -16,20 +16,24 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { observable, action } from 'mobx'
-import { get } from 'lodash'
+import { observable, action, computed } from 'mobx'
+import { get, assign } from 'lodash'
 
 export default class TerminalStore {
   username = get(globals, 'user.username', '')
 
-  @observable
-  kubeWebsocketUrl = ''
+  @computed
+  get kubeWebsocketUrl() {
+    const { namespace, pod, container, shell = 'sh' } = this.kubectl
+    return `kapis/terminal.kubesphere.io/v1alpha2/namespaces/${namespace}/pods/${pod}?container=${container}&shell=${shell}`
+  }
 
   @observable
   kubectl = {
     namespace: '',
     pod: '',
     container: '',
+    shell: 'bash',
     isLoading: false,
   }
 
@@ -39,17 +43,8 @@ export default class TerminalStore {
   @observable
   connected = false
 
-  getWebSocketUrl({ namespace, pod, container, shell = 'sh' }) {
-    return `kapis/terminal.kubesphere.io/v1alpha2/namespaces/${namespace}/pods/${pod}?container=${container}&shell=${shell}`
-  }
-
-  @action
-  async getKSWebSocketUrl() {
-    await this.fetchKubeCtl()
-    this.kubeWebsocketUrl = this.getWebSocketUrl({
-      ...this.kubectl,
-      shell: 'bash',
-    })
+  constructor(props) {
+    assign(this.kubectl, props)
   }
 
   @action


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

fix bug get buffer y prop when xterm.buffer is undefined

instead of getter by a method to get websocket link

**Which issue(s) this PR fixes**:

Fixes #32
