### PR TITLE
fix: create b2i service when push image to private image repo bug

### DIFF
--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -56,7 +56,15 @@ const updateS2iServiceParams = data => {
     'spec.template.spec.containers[0].name',
     ''
   )
-  const imageName = `${get(data.S2i, 'spec.config.imageName')}:${get(
+  let repoUrl = get(
+    data,
+    `S2i.metadata.annotations["kubesphere.io/repoUrl"]`,
+    ''
+  )
+  if (repoUrl && !repoUrl.endsWith('/')) {
+    repoUrl += '/'
+  }
+  const imageName = `${repoUrl}${get(data.S2i, 'spec.config.imageName')}:${get(
     data.S2i,
     'spec.config.tag'
   )}`


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug


**What this PR does / why we need it**:

when creating s2i service use private image repo, deployment image name not container private image   repo url, and cant get this image source. 