### PR TITLE
refactor: use base64 format in mail config api

### DIFF
--- a/src/stores/notification/mailService.js
+++ b/src/stores/notification/mailService.js
@@ -20,6 +20,8 @@ import { observable, action, computed } from 'mobx'
 import { get, includes, isString } from 'lodash'
 import cookie from 'utils/cookie'
 
+import logSVG from 'assets/logo.svg'
+
 import Base from './index'
 
 export default class AddressStore extends Base {
@@ -37,7 +39,7 @@ export default class AddressStore extends Base {
 
     this.config = params
     this.notificationEmailConfig = {
-      validation_icon: get(globals, 'config.logoUrl'),
+      validation_icon: logSVG,
       validation_title: '[KubeSphere] 测试邮件',
     }
   }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

use base64 format for alert mail config apis
