### PR TITLE
fix: miss sort filter in log query api

### DIFF
--- a/src/components/Modals/LogSearch/Logging/Detail/index.jsx
+++ b/src/components/Modals/LogSearch/Logging/Detail/index.jsx
@@ -46,7 +46,7 @@ export default class DetailModal extends React.Component {
       pathParams: {
         namespaces: namespace,
       },
-      sort: 'asc',
+      sort: 'desc',
       pods: pod,
       containers: container,
       size: 100,
@@ -180,13 +180,13 @@ export default class DetailModal extends React.Component {
       from: 0,
     })
 
-    this.logs.push(...logs)
-    this.scrollToBottom()
+    this.logs.unshift(...logs)
+    this.scrollToTop()
   }
 
-  scrollToBottom() {
+  scrollToTop() {
     const logWindow = this.logWindow.current
-    logWindow.scrollTop = logWindow.scrollHeight
+    logWindow.scrollTop = 0
   }
 
   stopPolling = () => {
@@ -321,6 +321,7 @@ export default class DetailModal extends React.Component {
   }
 
   renderLog() {
+    const { polling } = this.state
     return (
       <div className={styles.log}>
         <div
@@ -337,7 +338,7 @@ export default class DetailModal extends React.Component {
         </div>
         <div
           className={styles.terminal}
-          onScroll={this.onLogScroll}
+          onScroll={polling ? null : this.onLogScroll}
           ref={this.logWindow}
         >
           {this.renderTerminal()}

--- a/src/components/Modals/LogSearch/Logging/Detail/index.scss
+++ b/src/components/Modals/LogSearch/Logging/Detail/index.scss
@@ -94,7 +94,7 @@ $titleHeight: 30px;
       @at-root {
         .toolbar {
           &.pollingMode {
-            grid-template-columns: 1fr 32px 130px;
+            grid-template-columns: 1fr 32px 130px 32px;
           }
           padding: 8px 20px;
           line-height: 32px;

--- a/src/stores/logging/query.js
+++ b/src/stores/logging/query.js
@@ -85,6 +85,7 @@ export default class LoggingQuery extends LoggingStore {
       end_time: this.endTime,
       log_query: this.log_query,
       pods: this.pods,
+      sort: this.sort,
       containers: this.containers,
       from: this.from,
       size: this.size,


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

miss sort filter when fetching logs 

Fixes #48 

