### PR TITLE
fix/lose-default-interval-in-monitor-resource-page

### DIFF
--- a/src/pages/clusters/containers/MonitoringCenter/Monitoring/Resource/Usage/Physical/index.jsx
+++ b/src/pages/clusters/containers/MonitoringCenter/Monitoring/Resource/Usage/Physical/index.jsx
@@ -124,7 +124,7 @@ class PhysicalResource extends React.Component {
     return (
       <MonitoringController
         title={t('Cluster Resources Usage')}
-        step="60m"
+        step="1h"
         times={24}
         onFetch={this.fetchData}
         loading={isLoading}

--- a/src/pages/clusters/containers/MonitoringCenter/Monitoring/Resource/Usage/Virtual/index.jsx
+++ b/src/pages/clusters/containers/MonitoringCenter/Monitoring/Resource/Usage/Virtual/index.jsx
@@ -168,7 +168,7 @@ class VirtualResource extends React.Component {
     return (
       <MonitoringController
         title={t('Application Resources Usage')}
-        step="60m"
+        step="1h"
         times={24}
         onFetch={this.fetchData}
         loading={isLoading}


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**Which issue(s) this PR fixes**:
Fixes [#1621](https://github.com/kubesphere/kubesphere/issues/1621)

