### PR TITLE
fix: show pods status after build s2i

### DIFF
--- a/src/pages/projects/components/WorkloadStatus/index.jsx
+++ b/src/pages/projects/components/WorkloadStatus/index.jsx
@@ -34,7 +34,7 @@ export default function WorkloadStatus({ data, module }) {
       <div className={styles.status}>
         <Status
           type={statusResult}
-          name={t(S2I_STATUS_DESC[statusResult])}
+          name={t(S2I_STATUS_DESC[statusResult] || statusResult)}
           flicker
         />
       </div>

--- a/src/stores/container.js
+++ b/src/stores/container.js
@@ -127,6 +127,10 @@ export default class ContainerStore {
       null,
       () => true
     )
+
+    if (get(result, 'Code', 200) !== 200) {
+      result.status = 'failed'
+    }
     return ObjectMapper.imageBlob(result)
   }
 }

--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -25,11 +25,14 @@ export const getDeployStatus = ({
   annotations = {},
 }) => {
   if (hasS2i) {
-    return `${get(
+    const s2iStatus = get(
       annotations,
       "['devops.kubesphere.io/inithasbeencomplted']",
       'Running'
-    )}`
+    )
+    if (s2iStatus !== 'Successful') {
+      return s2iStatus
+    }
   }
 
   if (


### PR DESCRIPTION
after created s2i deployment, deploy lists only show `build image successful`, no more detail about pods status.

if build s2i success, show pods status