### PR TITLE
fix: jump to template list after template app create

### DIFF
--- a/src/pages/projects/containers/Applications/index.jsx
+++ b/src/pages/projects/containers/Applications/index.jsx
@@ -256,8 +256,9 @@ export default class Applications extends React.Component {
   }
 
   handleDeployRepoApp = () => {
+    const { namespace } = this.props.match.params
     this.hideRepoAppModal()
-    this.routing.query()
+    this.routing.push(`/projects/${namespace}/applications/template`)
   }
 
   renderHeader() {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/issues/1898

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```