### PR TITLE
fix: Fix openpitrix resources list orders

### DIFF
--- a/src/stores/openpitrix/base.js
+++ b/src/stores/openpitrix/base.js
@@ -131,6 +131,10 @@ export default class Base {
       conditions: getFilterString(conditions),
     }
 
+    if (reverse === undefined) {
+      reverse = true
+    }
+
     if (!isEmpty(filters)) {
       const filterStr = getFilterString(filters)
       params.conditions += filterStr ? `,${filterStr}` : ''


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
[issue 1900 question 1: the default version of Grafana is the oldest one. Should be the latest one.](https://github.com/kubesphere/kubesphere/issues/1900)