### PR TITLE
fix：delete a constant which is duplicate defined and unused 'Enter Workspace', there is a same constant 'View Workspace'

### DIFF
--- a/src/locales/zh/workspace.js
+++ b/src/locales/zh/workspace.js
@@ -30,7 +30,6 @@ export default {
   'Workspace Manager': '企业空间管理员',
   'Workspaces Manager': '企业空间管理员',
   'Create Workspace': '创建企业空间',
-  'Enter Workspace': '进入企业空间',
 
   'Projects Number': '项目数量',
   'DevOps Projects Number': 'DevOps 工程数量',


### PR DESCRIPTION
fix：a small issue, delete a constant which is duplicate defined and unused 'Enter Workspace', there is a same constant 'View Workspace'.

一个小的规范性问题：常量”Enter Workspace“没有用过，console中用到的是”View Workspace“。