### PR TITLE
fix(custom-monitor): can not generete metirc id when __name__ is null

### DIFF
--- a/src/stores/monitoring/custom/monitor.js
+++ b/src/stores/monitoring/custom/monitor.js
@@ -231,7 +231,7 @@ export default class PanelMonitor {
  */
 function parseExpr2GrafanaQuery({ __name__, ...reset } = {}) {
   if (!__name__) {
-    return ''
+    return JSON.stringify(reset || {})
   }
 
   const querys = Object.entries(reset || {}).map(


### PR DESCRIPTION
**What type of PR is this?**

**What this PR does / why we need it**:
fixing a bug when __name__ is null

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```