### PR TITLE
fix: Not allowed to select a cluster without Devops

### DIFF
--- a/src/components/Modals/DevOpsCreate/index.jsx
+++ b/src/components/Modals/DevOpsCreate/index.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react'
 import { observer } from 'mobx-react'
-import { isEmpty } from 'lodash'
+import { get, isEmpty } from 'lodash'
 import PropTypes from 'prop-types'
 import { Columns, Column, Select, Input, TextArea } from '@pitrix/lego-ui'
 import { Modal, Form } from 'components/Base'
@@ -75,6 +75,7 @@ export default class ProjectCreateModal extends React.Component {
       provider: item.provider,
       group: item.group,
       name: item.name,
+      disabled: !get(item, 'configz.devops', false),
     }))
   }
 
@@ -96,7 +97,14 @@ export default class ProjectCreateModal extends React.Component {
   valueRenderer = item => <ClusterTitle cluster={item} size="small" noStatus />
 
   optionRenderer = item => (
-    <ClusterTitle cluster={item} size="small" theme="light" noStatus />
+    <>
+      <ClusterTitle cluster={item} size="small" theme="light" noStatus />
+      {item.disabled && (
+        <div className={styles.toolmessage}>
+          <span>{t('NO_DEVOPS_INSTALL')}</span>
+        </div>
+      )}
+    </>
   )
 
   render() {

--- a/src/components/Modals/DevOpsCreate/index.scss
+++ b/src/components/Modals/DevOpsCreate/index.scss
@@ -27,14 +27,22 @@
   }
 
   .title {
-    & > div {
+    &>div {
       @include TypographyTitleH4($dark-color07);
     }
-  
-    & > p {
+
+    &>p {
       margin-top: 12px;
       @include TypographyParagraph($dark-color01);
     }
+  }
+}
+
+.toolmessage {
+  margin-left: 10px;
+
+  &>span {
+    vertical-align: middle;
   }
 }
 

--- a/src/locales/en/devops.js
+++ b/src/locales/en/devops.js
@@ -53,4 +53,6 @@ export default {
   DEVOPS_TIP_TYPE_Q: 'Which code repositories are supported by the Pipeline?',
   DEVOPS_TIP_TYPE_A:
     'The pipeline supports code repositories of git, github, SVN, and Bitbucket Server.',
+
+  NO_DEVOPS_INSTALL: 'DevOps not installed',
 }

--- a/src/locales/zh/devops.js
+++ b/src/locales/zh/devops.js
@@ -65,4 +65,6 @@ export default {
   DEVOPS_TIP_TYPE_Q: '流水线 (Pipeline) 支持哪些代码仓库类？',
   DEVOPS_TIP_TYPE_A:
     '流水线支持 Git、GitHub、SVN、以及 Bitbucket Server 代码仓库.',
+
+  NO_DEVOPS_INSTALL: '未安装 DevOps',
 }

--- a/src/pages/workspaces/containers/DevOps/index.jsx
+++ b/src/pages/workspaces/containers/DevOps/index.jsx
@@ -18,7 +18,6 @@
 
 import React from 'react'
 import { computed } from 'mobx'
-import { parse } from 'qs'
 
 import { Avatar } from 'components/Base'
 import Banner from 'components/Cards/Banner'
@@ -26,6 +25,7 @@ import Table from 'workspaces/components/ResourceTable'
 import withList, { ListPage } from 'components/HOCs/withList'
 
 import { getLocalTime } from 'utils'
+import { get } from 'lodash'
 
 import DevOpsStore from 'stores/devops'
 
@@ -92,6 +92,7 @@ export default class DevOps extends React.Component {
     return this.workspaceStore.clusters.data.map(item => ({
       label: item.name,
       value: item.name,
+      disabled: !get(item, 'configz.devops', false),
     }))
   }
 
@@ -109,7 +110,6 @@ export default class DevOps extends React.Component {
   }
 
   getData = async ({ silent, ...params } = {}) => {
-    this.query = parse(location.search.slice(1))
     const { store } = this.props
 
     silent && (store.list.silent = true)
@@ -126,17 +126,23 @@ export default class DevOps extends React.Component {
       title: t('Name'),
       dataIndex: 'name',
       width: '20%',
-      render: (name, record) => (
-        <Avatar
-          icon="strategy-group"
-          iconSize={40}
-          to={`/${this.workspace}/clusters/${
-            this.workspaceStore.cluster
-          }/devops/${record.namespace}`}
-          desc={record.description || '-'}
-          title={name}
-        />
-      ),
+      render: (name, record) => {
+        return (
+          <Avatar
+            icon="strategy-group"
+            iconSize={40}
+            to={
+              record.namespace && record.cluster
+                ? `/${this.workspace}/clusters/${record.cluster}/devops/${
+                    record.namespace
+                  }`
+                : null
+            }
+            desc={record.description || '-'}
+            title={name}
+          />
+        )
+      },
     },
     {
       title: t('ID'),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In the DevOps project, it is not judged whether there is DevOps in the current cluster