### PR TITLE
fix: Fix devops page when devops not installed

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -222,7 +222,13 @@ client:
           tabs:
             - { name: projects, title: Projects }
             - { name: federatedprojects, title: Multi-cluster Projects }
-        - { name: devops, title: DevOps Projects, icon: strategy-group }
+        - {
+            name: devops,
+            title: DevOps Projects,
+            icon: strategy-group,
+            # only work on single cluster mode.
+            singleClusterMoudle: devops,
+          }
         - name: apps
           title: Apps Management
           icon: appcenter

--- a/src/components/Tables/Base/index.jsx
+++ b/src/components/Tables/Base/index.jsx
@@ -67,7 +67,7 @@ export default class WorkloadTable extends React.Component {
     selectActions: PropTypes.array,
     extraProps: PropTypes.object,
     alwaysUpdate: PropTypes.bool,
-    emptyText: PropTypes.oneOfType([PropTypes.string || PropTypes.func]),
+    emptyText: PropTypes.any,
   }
 
   static defaultProps = {

--- a/src/core/global.js
+++ b/src/core/global.js
@@ -151,6 +151,10 @@ export default class GlobalValue {
       return false
     }
 
+    if (item.singleClusterMoudle && !globals.app.isMultiCluster) {
+      item.clusterModule = item.singleClusterMoudle
+    }
+
     if (
       item.clusterModule &&
       !this.hasClusterModule(item.cluster, item.clusterModule)

--- a/src/pages/workspaces/components/ResourceTable/index.jsx
+++ b/src/pages/workspaces/components/ResourceTable/index.jsx
@@ -77,7 +77,7 @@ class ResourceTable extends BaseTable {
 
   render() {
     const { clusters } = this.props
-    if (isEmpty(clusters)) {
+    if (globals.isMultiCluster && isEmpty(clusters)) {
       return (
         <EmptyList
           icon="cluster"

--- a/src/pages/workspaces/containers/DevOps/index.jsx
+++ b/src/pages/workspaces/containers/DevOps/index.jsx
@@ -25,7 +25,6 @@ import Table from 'workspaces/components/ResourceTable'
 import withList, { ListPage } from 'components/HOCs/withList'
 
 import { getLocalTime } from 'utils'
-import { get } from 'lodash'
 
 import DevOpsStore from 'stores/devops'
 
@@ -92,7 +91,6 @@ export default class DevOps extends React.Component {
     return this.workspaceStore.clusters.data.map(item => ({
       label: item.name,
       value: item.name,
-      disabled: !get(item, 'configz.devops', false),
     }))
   }
 

--- a/src/stores/devops.js
+++ b/src/stores/devops.js
@@ -130,14 +130,12 @@ export default class DevOpsStore extends Base {
       params.reverse = true
     }
 
-    let result = {}
-
-    try {
-      result = await request.get(
-        this.getDevOpsUrl({ cluster, workspace }),
-        params
-      )
-    } catch {}
+    const result = await request.get(
+      this.getDevOpsUrl({ cluster, workspace }),
+      params,
+      null,
+      () => {}
+    )
 
     const items = Array.isArray(get(result, 'items'))
       ? get(result, 'items')
@@ -152,7 +150,7 @@ export default class DevOpsStore extends Base {
 
     this.list.update({
       data,
-      total: result.total_count || data.length || 0,
+      total: get(result, 'total_count') || data.length || 0,
       limit: Number(limit) || 10,
       page: Number(page) || 1,
       order,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Hide devops nav when devops module not installed in single cluster mode.

Fix https://github.com/kubesphere/kubesphere/issues/2210