### PR TITLE
build: Add build stage into Dockerfile(x86_64)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,10 @@
 **
-!dist
-!server/(locales|public|sample|views|config.yaml)
+!cypress
+!scripts
+!server
+!src
+!babel.config.js
+!cypress.json
+!jest.config.js
 !package.json
 !yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,23 @@
-FROM node:8-alpine
+FROM node:10-alpine AS builder
+
+RUN apk add g++ gcc make python    
+
+WORKDIR /home/node
+COPY . .
+
+# Install dependencies and Build
+RUN yarn && yarn build
+
+
+FROM node:10-alpine
+
 RUN mkdir -p /root/KubeSphereUI
+
+COPY --from=builder /home/node/dist /root/KubeSphereUI/dist
+COPY --from=builder /home/node/server /root/KubeSphereUI/server
+COPY --from=builder /home/node/package.json /home/node/yarn.lock /root/KubeSphereUI/
+
 WORKDIR /root/KubeSphereUI
-COPY . /root/KubeSphereUI
 RUN mv dist/server.js server/server.js \
     && mv dist/fonts fonts
 EXPOSE 8000


### PR DESCRIPTION
Signed-off-by: imjoey <majunjiev@gmail.com>

**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Currently we need to rely on the local environment, such as `nodejs/yarn` to build the docker image and it would cause the build phrase inconsistent and non-producible. This PR is going to leverage multi-stage builds to move the build stage into Dockerfile.

> Note: This PR only add build stage support for the dockerfile of `x86_64`, while I would open another PR to make it for `arm64`.
