### PR TITLE
fix: Fix cluster nodes filter by role

### DIFF
--- a/src/stores/node.js
+++ b/src/stores/node.js
@@ -37,6 +37,16 @@ export default class NodeStore extends Base {
 
   module = 'nodes'
 
+  getFilterParams = params => {
+    const result = { ...params }
+    if (result.role) {
+      result.labelSelector = result.labelSelector || ''
+      result.labelSelector += `node-role.kubernetes.io/${result.role}=`
+      delete result.role
+    }
+    return result
+  }
+
   @action
   async fetchCount(params) {
     const resp = await request.get(this.getResourceUrl(params), {


### PR DESCRIPTION
Signed-off-by: leoliu <leoliu@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix cluster nodes filtered by role. Using `labelSelector=node-role.kubernetes.io/${role}` to instead the old way.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```