### PR TITLE
Update log receiver

### DIFF
--- a/src/locales/en/logging.js
+++ b/src/locales/en/logging.js
@@ -18,7 +18,7 @@
 
 export default {
   Activate: 'Activate',
-  'Add Log Collector': 'Add Log Collector',
+  'Add Log Receiver': 'Add Log Receiver',
   'Add Service Address': 'Add Service Address',
   Address: 'Address',
   'Auditing statistics': 'Auditing statistics',
@@ -26,7 +26,7 @@ export default {
   'Change Status': 'Change Status',
   Collecting: 'Collecting',
   'Current Statistics Start Time': 'Current Statistics Start Time',
-  'Delete Log Collector': 'Delete Log Collector',
+  'Delete Log Receiver': 'Delete Log Receiver',
   'Display Content': 'Display Content',
   'Event statistics': 'Event statistics',
   'Exact Query': 'Exact Query',
@@ -35,7 +35,7 @@ export default {
   'Index Prefix': 'Index Prefix',
   Keyword: 'Keyword',
   'Log Collections': 'Log Collections',
-  'Log Collector': 'Log Collector',
+  'Log Receiver': 'Log Receiver',
   'Log Management': 'Log Management',
   'Log Query': 'Log Query',
   'Log Start Time': 'Log Start Time',
@@ -78,7 +78,7 @@ export default {
   KAFKA_DESC: 'Kafka is a popular open-source stream-processing platform.',
   FLUENTD_DESC:
     'Fluentd is an open source data collector for unified logging layer.',
-  TOTAL_COLLECTIONS: 'Total {num} log collectors',
+  TOTAL_COLLECTIONS: 'Total {num} receivers',
   TOOLBOX_SHIFT_TIPS:
     ' 👻 You can open the page in a new window with "SHIFT + LEFT CLICK".',
 
@@ -91,7 +91,7 @@ export default {
   EMPTY_LOG_COLLECTIONS:
     'The log collector is not set up temporarily. You can add a log collector to export the log to the external log collector.',
   LOG_COLLECTION_TIPS:
-    'Only one log collector can be added for each type. If there is one already added, you are only allowed to edit it.',
+    'Only one log receiver can be added for each type. If there is one already added, you are only allowed to edit it.',
   URL_SYNTAX_ERROR: 'URL syntax error',
 
   LOG_COLLECTION_ES_URL_TIPS:
@@ -169,7 +169,7 @@ export default {
     'A total of <span class={className}> {auditing} </span> auditing logs were collected today.',
   NO_AUDITING_TODAY: 'Auditing logs not found today',
 
-  LOGGING_LOG_COLLECTOR: 'Log Collector',
-  EVENTS_LOG_COLLECTOR: 'Events Log Collector',
-  AUDITING_LOG_COLLECTOR: 'Auditing Log Collector',
+  LOGGING_LOG_COLLECTOR: 'Log Receiver',
+  EVENTS_LOG_COLLECTOR: 'Events Log Receiver',
+  AUDITING_LOG_COLLECTOR: 'Auditing Log Receiver',
 }

--- a/src/locales/es/logging.js
+++ b/src/locales/es/logging.js
@@ -18,7 +18,7 @@
 
 export default {
   Activate: 'Activar',
-  'Add Log Collector': 'Añadir el colector de logs',
+  'Add Log Receiver': 'Add Log Receiver',
   'Add Service Address': 'Agregar dirección de servicio',
   Address: 'Dirección',
   'Auditing statistics': 'Estadísticas de auditoría',
@@ -26,7 +26,7 @@ export default {
   'Change Status': 'Cambiar Estado',
   Collecting: 'Recolectar',
   'Current Statistics Start Time': 'Hora actual de inicio de estadísticas',
-  'Delete Log Collector': 'Eliminar el colector de logs',
+  'Delete Log Receiver': 'Delete Log Receiver',
   'Display Content': 'Mostrar el contenido',
   'Event statistics': 'Estadísticas de eventos',
   'Exact Query': 'Consulta exacta',
@@ -35,7 +35,7 @@ export default {
   'Index Prefix': 'Index Prefix',
   Keyword: 'Palabra clave',
   'Log Collections': 'Colecciones de logs',
-  'Log Collector': 'Colector de logs',
+  'Log Receiver': 'Log Receiver',
   'Log Management': 'Gestión de logs',
   'Log Query': 'Consulta de logs',
   'Log Start Time': 'Hora de inicio del log',
@@ -80,7 +80,7 @@ export default {
     'Kafka es una popular plataforma de procesamiento de flujo de código abierto.',
   FLUENTD_DESC:
     'Fluentd es un recopilador de datos de código abierto para la capa de registro unificada.',
-  TOTAL_COLLECTIONS: 'Total de {num} recolectores de registros',
+  TOTAL_COLLECTIONS: 'Total {num} receivers',
   TOOLBOX_SHIFT_TIPS:
     '👻 Puedes abrir la página en una nueva ventana con "MAYÚS + CLIC IZQUIERDO".',
   LOG_COLLECTION_DESC:
@@ -92,7 +92,7 @@ export default {
   EMPTY_LOG_COLLECTIONS:
     'El recopilador de logs no está configurado temporalmente. Puedes agregar un recopilador de logs para exportar el registro al recopilador de logs externo.',
   LOG_COLLECTION_TIPS:
-    'Solo se puedes agregar un recopilador de logs para cada tipo. Si ya hay uno agregado, solo puedes editarlo.',
+    'Only one log receiver can be added for each type. Si ya hay uno agregado, solo puedes editarlo.',
   URL_SYNTAX_ERROR: 'Error de sintaxis de URL',
   LOG_COLLECTION_ES_URL_TIPS:
     'El servicio incorporado Elasticsearch se usa de manera predeterminada. Puedes cambiarlo para usar un servicio Elasticsearch implementado por tí mismo dentro o fuera del clúster.',
@@ -168,7 +168,7 @@ export default {
   TOTAL_AUDITING_TODAY:
     'Hoy se han recopilado un total de <span class={className}>{auditing}</span> registros de auditoría.',
   NO_AUDITING_TODAY: 'Registros de auditoría no encontrados hoy',
-  LOGGING_LOG_COLLECTOR: 'Colector de logs',
-  EVENTS_LOG_COLLECTOR: 'Recopilador de registro de eventos',
-  AUDITING_LOG_COLLECTOR: 'Colector de logs de auditoría',
+  LOGGING_LOG_COLLECTOR: 'Log Receiver',
+  EVENTS_LOG_COLLECTOR: 'Events Log Receiver',
+  AUDITING_LOG_COLLECTOR: 'Auditing Log Receiver',
 }

--- a/src/locales/tc/application.js
+++ b/src/locales/tc/application.js
@@ -27,7 +27,7 @@ export default {
   Deploy: '部署',
   'Application Type': '應用類型',
   TOTAL_APPS: '共計 {num} 個應用',
-  TOTAL_COLLECTIONS: '共計 {num} 個接受者',
+  TOTAL_COLLECTIONS: '共計 {num} 個接收者',
   Upgrade: '升級',
   Rollback: '回滾',
 

--- a/src/locales/tc/logging.js
+++ b/src/locales/tc/logging.js
@@ -82,7 +82,7 @@ export default {
 
   LOG_COLLECTION_DESC:
     '系統將收集每個容器的標準輸出和標準錯誤輸出紀錄，並將其發送到一個或多個目標服務',
-  'Add Log Collector': '添加紀錄接收者',
+  'Add Log Receiver': '添加紀錄接收者',
   EMPTY_LOG_COLLECTIONS:
     '暫時没有設置紀錄收集器，您可以添加紀錄收集器將紀錄導出到外埠的紀錄收集工具中',
   LOG_COLLECTION_TIPS:
@@ -107,8 +107,8 @@ export default {
   Collecting: '收集中',
   'Change Status': '更改狀態',
   'Release Collection': '釋放收集',
-  'Delete Log Collector': '刪除紀錄接收者',
-  'Log Collector': '紀錄接收者',
+  'Delete Log Receiver': '刪除紀錄接收者',
+  'Log Receiver': '紀錄接收者',
   Activate: '啟用',
   'Real-Time Data': '實時數據',
   'Index Prefix': '索引前缀',

--- a/src/locales/zh/application.js
+++ b/src/locales/zh/application.js
@@ -27,7 +27,7 @@ export default {
   Deploy: '部署',
   'Application Type': '应用类型',
   TOTAL_APPS: '共计 {num} 个应用',
-  TOTAL_COLLECTIONS: '共计 {num} 个接受者',
+  TOTAL_COLLECTIONS: '共计 {num} 个接收者',
   Upgrade: '升级',
   Rollback: '回滚',
 

--- a/src/locales/zh/logging.js
+++ b/src/locales/zh/logging.js
@@ -80,7 +80,7 @@ export default {
 
   LOG_COLLECTION_DESC:
     '系统将收集每个容器的标准输出和标准错误输出日志，并将其发送到一个或多个目标服务',
-  'Add Log Collector': '添加日志接收者',
+  'Add Log Receiver': '添加日志接收者',
   EMPTY_LOG_COLLECTIONS:
     '暂时没有设置日志收集器，您可以添加日志收集器将日志导出到外埠的日志收集工具中',
   LOG_COLLECTION_TIPS:
@@ -105,8 +105,8 @@ export default {
   Collecting: '收集中',
   'Change Status': '更改状态',
   'Release Collection': '释放收集',
-  'Delete Log Collector': '删除日志接收者',
-  'Log Collector': '日志接收者',
+  'Delete Log Receiver': '删除日志接收者',
+  'Log Receiver': '日志接收者',
   Activate: '激活',
   'Real-Time Data': '实时数据',
   'Index Prefix': '索引前缀',

--- a/src/pages/clusters/containers/LogCollections/Detail/index.jsx
+++ b/src/pages/clusters/containers/LogCollections/Detail/index.jsx
@@ -97,7 +97,7 @@ export default class LogCollectionDetail extends React.Component {
     },
     {
       key: 'delete',
-      text: t('Delete Log Collector'),
+      text: t('Delete Log Receiver'),
       icon: 'trash',
       action: 'delete',
       type: 'danger',

--- a/src/pages/clusters/containers/LogCollections/index.jsx
+++ b/src/pages/clusters/containers/LogCollections/index.jsx
@@ -149,7 +149,7 @@ export default class LogCollection extends React.Component {
         disabled={this.store.list.isLoading}
         onClick={this.showCreateModal}
       >
-        {t('Add Log Collector')}
+        {t('Add Log Receiver')}
       </Button>
     )
   }


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

/kind documentation

**What this PR does / why we need it**:

Update the translation of “接收者” to "receiver" instead of "collector".

No change is needed for Traditional Chinese. I will notify our Spanish partner of this change after the pr is merged.