### PR TITLE
fix: Fix redis session expire time too long

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -23,7 +23,7 @@ server:
 
   # kubesphere console session params, not login session
   sessionKey: 'kubesphere:sess'
-  sessionTimeout: 7200000 # unit: millisecond
+  sessionTimeout: 3600000 # unit: millisecond
 
   # backend service gateway server
   apiServer:

--- a/server/store/index.js
+++ b/server/store/index.js
@@ -50,10 +50,9 @@ class RedisStore extends Store {
     return JSON.parse(data)
   }
 
-  // maxAge unit is second.
-  async set(session, { sid = uid.sync(24), maxAge = 3600 } = {}) {
+  async set(session, { sid = uid.sync(24), maxAge = 3600000 } = {}) {
     await this.redis
-      .set(`sid-${sid}`, JSON.stringify(session), 'EX', maxAge)
+      .set(`sid-${sid}`, JSON.stringify(session), 'EX', maxAge / 1000)
       .catch(this.catch)
 
     return sid


### PR DESCRIPTION
Signed-off-by: leoliu <leoliu@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The TTL of the session is too long.  Creating sessions frequently will consume a lot of memory.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

![image](https://user-images.githubusercontent.com/8739949/97852113-47caad00-1d31-11eb-82c8-ef0cd5dbe8f0.png)


<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```