### PR TITLE
fix TypeSelect is not defined

### DIFF
--- a/src/pages/projects/components/Modals/RepoApp/AppDetail/index.jsx
+++ b/src/pages/projects/components/Modals/RepoApp/AppDetail/index.jsx
@@ -26,6 +26,7 @@ import { Button, RadioGroup, Columns, Column } from '@kube-design/components'
 
 import AppPreview from 'appStore/components/AppPreview'
 import AppBase from 'appStore/components/AppBase'
+import TypeSelect from '../../../../../../components/Base/TypeSelect'
 
 import AppStore from 'stores/openpitrix/app'
 import VersionStore from 'stores/openpitrix/version'


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:

TypeSelect component define but not import


**Which issue(s) this PR fixes**:
Fix the  TypeSelect component not import  triggered by ` Uncaught ReferenceError: TypeSelect is not defined`

Fixes #1291 
