### PR TITLE
change K8S/k8s to K8s which is the official spelling from Kubernetes

### DIFF
--- a/src/locales/en/monitoring.js
+++ b/src/locales/en/monitoring.js
@@ -50,7 +50,7 @@ export default {
   'gRPC Stream Messages': 'gRPC Stream Messages',
   'Historical Monitoring': 'Historical Monitoring',
   'inode Utilization': 'inode Utilization',
-  'K8S Scheduler': 'K8S Scheduler',
+  'K8s Scheduler': 'K8s Scheduler',
   Monitoring: 'Monitoring',
   'Monitoring Center': 'Monitoring Center',
   ms: 'ms',

--- a/src/locales/en/storage.js
+++ b/src/locales/en/storage.js
@@ -74,7 +74,7 @@ export default {
   VOLUME_SNAPSHOT_STATUS_FAILED: 'Created unsuccessfully',
   VOLUME_SNAPSHOT_STATUS_READY: 'Created successfully',
   volumes: 'volumes',
-  VolumeSnapshots: 'VolumeSnapshots',
+  VolumeSnapshots: 'Volume Snapshots',
 
   'Storage Classs': 'Storage Classes',
   ACCESS_MODE_RWO: 'Single node read-write',

--- a/src/locales/es/monitoring.js
+++ b/src/locales/es/monitoring.js
@@ -51,7 +51,7 @@ export default {
   'gRPC Stream Messages': 'Mensajes de stream de gRPC',
   'Historical Monitoring': 'Datos de monitorización históricos',
   'inode Utilization': 'Utilización de inode',
-  'K8S Scheduler': 'Scheduler K8S',
+  'K8s Scheduler': 'Scheduler K8s',
   Monitoring: 'Monitorización',
   'Monitoring Center': 'Centro de monitorización',
   ms: 'ms',

--- a/src/locales/es/storage.js
+++ b/src/locales/es/storage.js
@@ -75,7 +75,7 @@ export default {
   VOLUME_SNAPSHOT_STATUS_FAILED: 'Created unsuccessfully',
   VOLUME_SNAPSHOT_STATUS_READY: 'Created successfully',
   volumes: 'volúmenes',
-  VolumeSnapshots: 'VolumeSnapshots',
+  VolumeSnapshots: 'Volume Snapshots',
   'Storage Classs': 'Clases de almacenamiento',
   ACCESS_MODE_RWO: 'Nodo único de lectura y escritura',
   ACCESS_MODE_ROX: 'Multi-nodo de solo lectura',

--- a/src/locales/tc/monitoring.js
+++ b/src/locales/tc/monitoring.js
@@ -56,7 +56,7 @@ export default {
   'Abnormal Pods': '異常容器組',
 
   'Controller Manager': '管理控制中心',
-  'K8S Scheduler': 'K8s 調度器',
+  'K8s Scheduler': 'K8s 調度器',
   Scheduler: '調度器',
   Node: '節點',
 

--- a/src/locales/zh/monitoring.js
+++ b/src/locales/zh/monitoring.js
@@ -56,7 +56,7 @@ export default {
   'Abnormal Pods': '异常容器组',
 
   'Controller Manager': '管理控制中心',
-  'K8S Scheduler': 'K8s 调度器',
+  'K8s Scheduler': 'K8s 调度器',
   Scheduler: '调度器',
   Node: '节点',
 

--- a/src/pages/clusters/containers/Monitor/Cluster/Overview/index.jsx
+++ b/src/pages/clusters/containers/Monitor/Cluster/Overview/index.jsx
@@ -227,7 +227,7 @@ class Overview extends React.Component {
       },
       {
         type: 'scheduler',
-        name: t('K8S Scheduler'),
+        name: t('K8s Scheduler'),
       },
       {
         type: 'node',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -249,7 +249,7 @@ export const MODULE_KIND_MAP = {
   secrets: 'Secret',
   s2ibuilders: 'S2iBuilder',
   nodes: 'Node',
-  volumesnapshots: 'VolumeSnapshot',
+  volumesnapshots: 'Volume Snapshot',
   namespaces: 'Namespace',
   workspaces: 'WorkspaceTemplate',
   clusters: 'Cluster',

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -459,7 +459,7 @@ export const replaceToLocalOrigin = url => {
 }
 
 /**
- * send the k8s requests with dry run
+ * send the K8s requests with dry run
  * @param {Object[]} requests - the requests need dry run.
  * @param {string} requests[].url - the url of a request
  * @param {Object} requests[].data - the data of a request


### PR DESCRIPTION
Signed-off-by: Ray Zhou <ray@yunify.com>

**What type of PR is this?**

/kind cleanup