### PR TITLE
fix: Add app.kubernetes.io/vendor label for service monitor

### DIFF
--- a/src/components/Base/Panel/index.jsx
+++ b/src/components/Base/Panel/index.jsx
@@ -46,9 +46,7 @@ export default class Panel extends React.Component {
       >
         {title && <div className={styles.title}>{title}</div>}
         <div className={classNames(styles.panel, className)}>
-          <Loading spinning={loading}>
-            <>{children || empty}</>
-          </Loading>
+          {loading ? <Loading className={styles.loading} /> : children || empty}
         </div>
         {extras}
       </div>

--- a/src/components/Base/Panel/index.scss
+++ b/src/components/Base/Panel/index.scss
@@ -26,3 +26,8 @@
   font-weight: $font-bold;
   color: $light-color07;
 }
+
+.loading {
+  margin-left: 50%;
+  transform: translateX(-50%);
+}

--- a/src/pages/projects/components/Modals/ServiceMonitor/index.jsx
+++ b/src/pages/projects/components/Modals/ServiceMonitor/index.jsx
@@ -87,7 +87,10 @@ export default class ServiceMonitor extends Component {
       item => item.name === this.state.selectServiceName
     )
     set(data, 'spec.selector.matchLabels', selectService.labels)
-    set(data, 'metadata.labels', selectService.labels)
+    set(data, 'metadata.labels', {
+      ...(selectService.labels || {}),
+      'app.kubernetes.io/vendor': 'kubesphere',
+    })
 
     onOk(data)
   }


### PR DESCRIPTION
Signed-off-by: leoliu <leoliu@yunify.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Add preset label {'app.kubernetes.io/vendor': 'kubesphere'} to service monitor yaml.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```