### PR TITLE
fix: Filter kiali graph data with servcie app label

### DIFF
--- a/src/stores/application/crd.js
+++ b/src/stores/application/crd.js
@@ -133,15 +133,15 @@ export default class ApplicationStore extends Base {
       request.get(this.getHealthUrl({ cluster, namespace, type: 'workload' })),
     ])
 
-    const serviceNames =
+    const serviceAppLabels =
       serviceResult && serviceResult.items
-        ? serviceResult.items.map(item => get(item, 'metadata.name'))
+        ? serviceResult.items.map(item => get(item, 'metadata.labels.app'))
         : []
 
     if (result && result.elements) {
       const nodes = []
       result.elements.nodes.forEach(node => {
-        if (serviceNames.includes(node.data.app)) {
+        if (serviceAppLabels.includes(node.data.app)) {
           nodes.push(node)
         }
 
@@ -155,7 +155,7 @@ export default class ApplicationStore extends Base {
     }
 
     if (appHealth && serviceHealth && workloadHealth) {
-      this.graph.health = serviceNames.reduce(
+      this.graph.health = serviceAppLabels.reduce(
         (prev, cur) => ({
           ...prev,
           [cur]: {


### PR DESCRIPTION
Signed-off-by: leoliu <leoliu@yunify.com>

**What type of PR is this?**

**What this PR does / why we need it**:

The console filtered the kiali graph data with the services' names and the nodes' app value.
That should be changed to services' `metadata.labels.app`.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```