### PR TITLE
fix: Display the name and alias in Applications details page

### DIFF
--- a/src/pages/projects/components/Cards/Ingresses/Item.jsx
+++ b/src/pages/projects/components/Cards/Ingresses/Item.jsx
@@ -21,6 +21,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Link } from 'react-router-dom'
 import { Button, Icon } from '@kube-design/components'
+import { getDisplayName } from 'utils'
 
 import styles from './index.scss'
 
@@ -42,13 +43,14 @@ const Card = ({ detail, gateway, prefix }) => {
   }
 
   const tls = detail.tls[0] || {}
+  const detailName = getDisplayName(detail)
 
   return (
     <div className={styles.card}>
       <div className={styles.content}>
         <Icon name="loadbalancer" size={40} />
         <div className={styles.text}>
-          <Link to={`${prefix}/${detail.name}`}>{detail.name}</Link>
+          <Link to={`${prefix}/${detail.name}`}>{detailName}</Link>
           <p>hostname: {detail.rules.map(rule => rule.host).join(', ')}</p>
         </div>
       </div>

--- a/src/pages/projects/components/Cards/Services/Item.jsx
+++ b/src/pages/projects/components/Cards/Services/Item.jsx
@@ -25,6 +25,7 @@ import classnames from 'classnames'
 import { Tooltip, Icon } from '@kube-design/components'
 import { Text } from 'components/Base'
 import ServiceAccess from 'projects/components/ServiceAccess'
+import { getDisplayName } from 'utils'
 
 import styles from './index.scss'
 
@@ -48,6 +49,7 @@ export default class ServiceItem extends React.Component {
     }
 
     const serviceMonitor = get(detail, 'monitor.name')
+    const detailName = getDisplayName(detail)
 
     return (
       <div className={classnames(styles.item, className)}>
@@ -55,7 +57,7 @@ export default class ServiceItem extends React.Component {
           icon="network-router"
           title={
             <>
-              <Link to={`${prefix}/${detail.name}`}>{detail.name}</Link>
+              <Link to={`${prefix}/${detail.name}`}>{detailName}</Link>
               {serviceMonitor && (
                 <Tooltip
                   content={`${t('Monitoring Exporter')}: ${serviceMonitor}`}

--- a/src/pages/projects/components/Cards/Workloads/Item.jsx
+++ b/src/pages/projects/components/Cards/Workloads/Item.jsx
@@ -22,7 +22,7 @@ import { Link } from 'react-router-dom'
 import PropTypes from 'prop-types'
 
 import { List } from 'components/Base'
-import { getLocalTime } from 'utils'
+import { getLocalTime, getDisplayName } from 'utils'
 import { getWorkloadStatus } from 'utils/status'
 import { ICON_TYPES, S2I_STATUS_DESC } from 'utils/constants'
 import StatusReason from 'projects/components/StatusReason'
@@ -88,6 +88,7 @@ export default class WorkloadItem extends React.Component {
     }
 
     const { status, reason } = this.getStatus(detail)
+    const detailName = getDisplayName(detail)
 
     const details = [
       {
@@ -121,7 +122,7 @@ export default class WorkloadItem extends React.Component {
         className={styles.item}
         title={
           <Link to={`${prefix}/${detail.type}/${detail.name}`}>
-            {detail.name}
+            {detailName}
           </Link>
         }
         description={this.getDescription(reason, status, detail)}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind optimization

**What this PR does / why we need it**:

In some application scenarios, users will pay attention to the alias , not only the name.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1351
