### PR TITLE
Fix the wrong query of pipeline list

### DIFF
--- a/src/stores/devops/pipelines.js
+++ b/src/stores/devops/pipelines.js
@@ -142,8 +142,8 @@ export default class PipelineStore extends BaseStore {
         start: (page - 1) * TABLE_LIMIT || 0,
         limit: TABLE_LIMIT,
         q: `type:pipeline;organization:jenkins;pipeline:${devops}/${searchWord ||
-          '*'};excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject&filter=${filter ||
-          'no-folders'}`,
+          '*'};excludedFromFlattening:jenkins.branch.MultiBranchProject,hudson.matrix.MatrixProject`,
+        filter: `${filter || 'no-folders'}`,
       },
       { params: { ...filters } }
     )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area devops

**What this PR does / why we need it**:

Fixes kubesphere/kubesphere#3102

**Special notes for reviewers**:

The wrong request is:
`http://localhost:8000/kapis/devops.kubesphere.io/v1alpha2/search?start=0&limit=10&q=type%3Apipeline%3Borganization%3Ajenkins%3Bpipeline%3Aasdfjgq2f%2F%2A%3BexcludedFromFlattening%3Ajenkins.branch.MultiBranchProject%2Chudson.matrix.MatrixProject%26filter%3Dno-folders`

The correct request is:
`http://localhost:8000/kapis/devops.kubesphere.io/v1alpha2/search?start=0&limit=10&q=type%3Apipeline%3Borganization%3Ajenkins%3Bpipeline%3Aasdfjgq2f%2F%2A%3BexcludedFromFlattening%3Ajenkins.branch.MultiBranchProject%2Chudson.matrix.MatrixProject&filter=no-folder`

**Additional documentation, usage docs, etc.**:
