### PR TITLE
Fix the wrong job filter with job search API

### DIFF
--- a/src/components/Forms/Pipelines/AdvanceSettings/index.jsx
+++ b/src/components/Forms/Pipelines/AdvanceSettings/index.jsx
@@ -105,7 +105,7 @@ export default class AdvanceSettings extends React.Component {
       devopsName,
       devops,
       cluster,
-      filter: 'no-multi-branch-job',
+      filter: 'no-folders',
     })
   }
 
@@ -165,7 +165,7 @@ export default class AdvanceSettings extends React.Component {
       devopsName,
       cluster,
       devops,
-      filter: 'no-multi-branch-job',
+      filter: 'no-folders',
       page: page + 1,
     })
   }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/area devops

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:

The error log output from Jenkins:

```
2020-12-28 06:16:36.495+0000 [id=14]    WARNING h.i.i.InstallUncaughtExceptionHandler#handleException: Caught unhandled exception with ID bd273797-7a0f-44a4-a88f-25113a0f4809
java.lang.IllegalArgumentException: Invalid filter type specified.
        at io.jenkins.blueocean.service.embedded.rest.ContainerFilter.getFilters(ContainerFilter.java:95)
        at io.jenkins.blueocean.service.embedded.rest.ContainerFilter.filter(ContainerFilter.java:46)
        at io.jenkins.blueocean.service.embedded.rest.ContainerFilter.filter(ContainerFilter.java:39)
        at io.jenkins.blueocean.service.embedded.rest.PipelineSearch.search(PipelineSearch.java:100)
        at io.jenkins.blueocean.rest.ApiHead.search(ApiHead.java:61)
        at java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:627)
        at org.kohsuke.stapler.Function$MethodFunction.invoke(Function.java:396)
        at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:408)
        at org.kohsuke.stapler.ForwardingFunction.invoke(ForwardingFunction.java:83)
        at io.jenkins.blueocean.rest.pageable.PagedResponse$Processor.invoke(PagedResponse.java:42)
        at org.kohsuke.stapler.PreInvokeInterceptedFunction.invoke(PreInvokeInterceptedFunction.java:26)
        at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:212)
        at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:145)
        at org.kohsuke.stapler.MetaClass$11.doDispatch(MetaClass.java:536)
        at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:58)
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:766)
Caused: javax.servlet.ServletException
        at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:816)
```

![image](https://user-images.githubusercontent.com/1450685/103193850-a28b1a00-4918-11eb-9486-9249879654da.png)

The screenshot after using the correct parameter:

![image](https://user-images.githubusercontent.com/1450685/103193875-b46cbd00-4918-11eb-9057-410e98d5b731.png)

**Additional documentation, usage docs, etc.**:
The possible value contains: [no-folders](https://github.com/jenkinsci/blueocean-plugin/blob/219eee27a710fde6e455a64d1d4bca5331f6119b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineJobFilters.java#L23), [origin](https://github.com/jenkinsci/blueocean-plugin/blob/219eee27a710fde6e455a64d1d4bca5331f6119b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineJobFilters.java#L37), [pull-request](https://github.com/jenkinsci/blueocean-plugin/blob/219eee27a710fde6e455a64d1d4bca5331f6119b/blueocean-pipeline-api-impl/src/main/java/io/jenkins/blueocean/rest/impl/pipeline/PipelineJobFilters.java#L51)
