### PR TITLE
Delete Chinese guillemets

### DIFF
--- a/src/pages/apps/components/Modals/AppCreate/index.jsx
+++ b/src/pages/apps/components/Modals/AppCreate/index.jsx
@@ -72,7 +72,7 @@ export default class AppCreate extends Component {
                 target="_blank"
                 rel="noreferrer noopener"
               >
-                《{t('HELM_DEVELOP_GUIDE')}》
+                {t('HELM_DEVELOP_GUIDE')}
               </a>
             </div>
           </div>

--- a/src/pages/apps/components/Modals/HelmUpload/index.jsx
+++ b/src/pages/apps/components/Modals/HelmUpload/index.jsx
@@ -169,7 +169,7 @@ export default class HelmUpload extends Component {
             target="_blank"
             rel="noreferrer noopener"
           >
-            《{t('HELM_DEVELOP_GUIDE')}》
+            {t('HELM_DEVELOP_GUIDE')}
           </a>
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: Sherlock113 <sherlockxu@yunify.com>

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

The Chinese guillemets should be used only for Chinese. Not applicable to English.