### PR TITLE
Fix typo in Traditional Chinese translations

### DIFF
--- a/locales/tc/alerting.js
+++ b/locales/tc/alerting.js
@@ -95,8 +95,8 @@ module.exports = {
   Condition: '條件',
   Threshold: '臨界值',
 
-  ALERT_TYPE: '{type}告警',
-  ALERT_POLICY_TYPE: '{type}告警策略',
+  ALERT_TYPE: ' {type} 告警',
+  ALERT_POLICY_TYPE: ' {type} 告警策略',
   ALERT_POLICY_DESC: '設置告警規則',
   ALERT_MESSAGE_DESC:
     '告警訊息紀錄了在工作負載級别的告警策略中，所有已發出的滿足告警規則的告警訊息。',
@@ -116,7 +116,7 @@ module.exports = {
   CONSECUTIVE_OPTIONS: '連續 {value} 次',
 
   MAX_SEND_NOT_LIMIT: '不限制',
-  MAX_SEND_COUNT: '最多重發{count}次',
+  MAX_SEND_COUNT: '最多重發 {count} 次',
   REPEAT_CUSTOM_TITLE: '自定義重復規則',
   REPEAT_CUSTOM_DESC:
     '告警規則將根據危險程度進行重復推送，如果未進行修改將會按照預設策略運行',
@@ -174,12 +174,12 @@ module.exports = {
   'Unavailable daemonset replicas ratio': '守護進程集副本不可用率',
   'Unavailable statefulset replicas ratio': '有狀態集副本不可用率',
 
-  REQUESTS_FOR_TRIGGER_AN_ALARM_Q: '觸發告警訊息的前提條件?',
+  REQUESTS_FOR_TRIGGER_AN_ALARM_Q: '觸發告警訊息的前提條件？',
   REQUESTS_FOR_TRIGGER_AN_ALARM_A:
     '需要對資源設置告警策略，當資源某項指標達到了告警策略的臨界值後即會觸發並推送訊息。',
-  REQUESTS_FOR_PUSH_AN_ALARM_Q: '告警策略訊息推送的前提條件?',
+  REQUESTS_FOR_PUSH_AN_ALARM_Q: '告警策略訊息推送的前提條件？',
   REQUESTS_FOR_PUSH_AN_ALARM_A: '需要平台管理員設置郵件伺服器。',
-  HOW_TO_SUPRESS_AN_ALARM_Q: '如何對告警訊息進行抑制?',
+  HOW_TO_SUPRESS_AN_ALARM_Q: '如何對告警訊息進行抑制？',
   HOW_TO_SUPRESS_AN_ALARM_A:
     '可以對每條告警策略進行多級别的設置，每个級别對應不同的告警週期及重復週期',
 

--- a/locales/tc/app.js
+++ b/locales/tc/app.js
@@ -55,9 +55,9 @@ module.exports = {
   APP_ABSTRACTION_DESC: '對應用的概括性介紹',
   APP_DETAIL_DESC: '在用戶搜索應用時會非常有幫助',
   'Upload Icon': '上傳圖標',
-  APP_ICON_NOTE: '96px*96px 以内 JPG 或者 PNG',
+  APP_ICON_NOTE: '96px * 96px 以内 JPG 或者 PNG',
   APP_ICON_FORMAT: '格式: PNG 背景透明最佳',
-  APP_ICON_SIZE: '圖形大小: 96px*96px',
+  APP_ICON_SIZE: '圖形大小: 96px * 96px',
   'Start edit': '開始編輯',
   File: '檔案',
   'Platform App Store Management': '平台級應用商店管理',
@@ -113,7 +113,7 @@ module.exports = {
   APP_TEMPLATES_DESC:
     'KubeSphere 提供全生命週期的應用管理，可以上傳或者創建新的應用模板，並且快速部署它們，也可以通過應用商店進行發佈應用。',
   UPLOAD_HELM_TITLE: '上傳 Helm 配置文件',
-  UPLOAD_HELM_DESC: '上傳已有的 Helm  Chart ',
+  UPLOAD_HELM_DESC: '上傳已有的 Helm Chart ',
   'Edit App Informatio': '編輯應用資訊',
   EDIT_APP_DESC: '對應用的基本資訊進行設置',
   'App Number': '應用編號',
@@ -174,7 +174,7 @@ module.exports = {
   'Edit App Information': '編輯應用資訊',
   Uncategorized: '未分類',
   'Category Name': '分類名稱',
-  CATEGORY_NAME_DESC: '建議不超過8個字元，最多能輸入20個字元',
+  CATEGORY_NAME_DESC: '建議不超過 8 個字元，最多能輸入 20 個字元',
   'Please input category name': '請輸入分類名稱',
   ICON_DESC: '請選擇一個圖示來標示分類',
   'Please select icon': '請選擇圖示',
@@ -216,7 +216,7 @@ module.exports = {
 
   APP_CATE_UNCATEGORIZED: '未分類',
 
-  MISS_FILE_NOTE: '文件{file}没有找到',
+  MISS_FILE_NOTE: '文件 {file} 没有找到',
 
   'Please select a project to deploy': '請選擇項目部署',
   'Please select a workspace': '請選擇企業空間',
@@ -231,7 +231,7 @@ module.exports = {
 
   DELETE_APP_TEMPLATE_TIP: '刪除應用模板前，需要先刪除所有版本。',
 
-  UNPROCESSED_APP_REVIEW: '未处理的应用审核',
-  PROCESSED_APP_REVIEW: '已处理的应用审核',
-  ALL_APP_REVIEW: '应用审核',
+  UNPROCESSED_APP_REVIEW: '未處理的應用審核',
+  PROCESSED_APP_REVIEW: '已處理的應用審核',
+  ALL_APP_REVIEW: '應用審核',
 }

--- a/locales/tc/application.js
+++ b/locales/tc/application.js
@@ -86,7 +86,7 @@ module.exports = {
   'TCP - Outbound Traffic': 'TCP - 出站流量',
 
   'Connection timeout': '連接超時時間',
-  'TCP connection timeout.': 'TCP連接超時時間。',
+  'TCP connection timeout.': 'TCP 連接超時時間。',
   'Maximum requests': '最大請求數',
   'Maximum pending requests': '最大等待請求數(等待列隊的長度)',
   'Max request retries': '最大請求重試次數',
@@ -97,7 +97,7 @@ module.exports = {
     '對後端連接中最大的請求數量若設為1則會禁止 keep alive 特性。',
   'Max number of connections': '最大連接數',
   'The maximum number of HTTP1 or TCP connections to the target host.':
-    '到目標主機HTTP1或TCP連接的最大數量。',
+    '到目標主機 HTTP1 或 TCP 連接的最大數量。',
   'Load balance algorithm': '負載平衡算法',
   'Session retention': '會話保持',
 
@@ -190,7 +190,7 @@ module.exports = {
   Log: '紀錄',
 
   POD_ISOLATION_RATIO_DESC:
-    '允許容器組被隔離的最大比例。採用向上取整，若10个實例，設為13% 則最多會隔離2个實例',
+    '允許容器組被隔離的最大比例。採用向上取整，若 10 個實例，設為 13% 則最多會隔離 2 個實例',
   BASE_EJECTION_TIME_DESC:
     '容器組第一次被隔離的時間，之後每次隔離時間為次數與最短隔離時間的乘積',
   CIRCUIT_DESC:
@@ -207,7 +207,7 @@ module.exports = {
     '根據應用中服務類型的不同設置不同類型的服務組件，支持無狀態服務和有狀態服務',
   APPLICATION_BASEINFO_DESC: 'ˇ對應用的名稱描述資訊等基本的資訊定義',
 
-  HOW_TO_USE_APPLICATION_GOVE_Q: '如何使用應用治理?',
+  HOW_TO_USE_APPLICATION_GOVE_Q: '如何使用應用治理？',
   HOW_TO_USE_APPLICATION_GOVE_A:
     '使用應用治理需要創建自制應用並對每項服務開啟服務治理功能',
 
@@ -227,7 +227,7 @@ module.exports = {
     '來自於企業空間的自制應用模板以及應用倉庫中添加的第三方 Helm 應用模板',
   COMPOSING_APP_DESC: '通過資源編排的方式發佈服務構建應用(支持應用治理功能)',
   APP_TEMPLATES_MODAL_DESC:
-    '應用模板來自於企業空間和第三方的 Helm 應用模板，支持一鍵部署並可通過視覺化的方式 在KubeSphere 中展示並提供部署及管理的功能',
+    '應用模板來自於企業空間和第三方的 Helm 應用模板，支持一鍵部署並可通過視覺化的方式在 KubeSphere 中展示並提供部署及管理的功能',
   APP_REPOS_DESC:
     '應用倉庫來自於第三方的 Helm Chart Repo，通過視覺化的方式在 KubeSphere 中展示並提供部署及管理功能，用戶可以基於應用倉庫中的模板快速地一鍵部署應用。',
   SEARCH_TIPS: '您可以根據相關條件進行過濾',
@@ -236,13 +236,13 @@ module.exports = {
   'Add stateful or stateless services': '添加有狀態服務或無狀態服務',
   'Add Internet access rule for the application': '為應用添加外網訪問規則',
 
-  INTERNET_ACCESS_DESC: '可以設置應用的外網訪問規則(Ingress)',
+  INTERNET_ACCESS_DESC: '可以設置應用的外網訪問規則 (Ingress)',
 
   'Microservice enabled': '微服務已啟用',
   'Microservice not enabled': '微服務未啟用',
 
   TRAFFIC_MANAGEMENT_NO_MICROSERVICE_TIP:
-    '流量治理依賴於微服務模組, 目前集群未啟用微服務模組',
+    '流量治理依賴於微服務模組，目前集群未啟用微服務模組',
   TRACING_NO_MICROSERVICE_TIP:
-    'Tracing 依賴於微服務模組, 目前集群未啟用微服務模組',
+    'Tracing 依賴於微服務模組，目前集群未啟用微服務模組',
 }

--- a/locales/tc/base.js
+++ b/locales/tc/base.js
@@ -179,9 +179,9 @@ module.exports = {
   NUM_UNIT: '個',
   Password: '密碼',
 
-  NOT_ENABLE: '{resource}暫未啟用',
-  NOT_AVAILABLE: '暫時没有可用的{resource}',
-  NO_RESOURCE: '暫時没有{resource}',
+  NOT_ENABLE: '{resource} 暫未啟用',
+  NOT_AVAILABLE: '暫時没有可用的 {resource}',
+  NO_RESOURCE: '暫時没有 {resource}',
   RESOURCE_NOT_FOUND: '很抱歉，没有找到您所尋找的資源。',
   'No Available Resource': '暫無可用資源',
   'No Data': '暫無數據',
@@ -271,11 +271,11 @@ module.exports = {
   LONG_NAME_TOO_LONG: '最長 253 個字元',
   ALIAS_DESC: '别名可以由任意字元组成，幫助您更好的區分資源，最長 63 個字元。',
   LABEL_FORMAT_DESC:
-    '標籤的 key 和 value 最長 63 個字元，key 如果包含域名, 則最長 253 字元。只能包含大小寫字母、數字, 分隔符號("-")，下底線(_)及小數點(.)，且必須以數字或大小寫開頭和結尾',
+    '標籤的 key 和 value 最長 63 個字元，key 如果包含域名，則最長 253 字元。只能包含大小寫字母、數字，分隔符號("-")，下底線(_)及小數點(.)，且必須以數字或大小寫開頭和結尾',
   DESCRIPTION_DESC: '描述資訊不超過 256 個字元',
-  PROJECT_DESC: '將根據項目資源進行分組, 可以按項目對資源進行查看管理',
+  PROJECT_DESC: '將根據項目資源進行分組，可以按項目對資源進行查看管理',
   'MULTI-CLUSTER_PROJECT_CREATE_DESC':
-    '將根據項目資源進行分組, 可以按項目對資源進行查看管理',
+    '將根據項目資源進行分組，可以按項目對資源進行查看管理',
   Description: '描述資訊',
 
   'Please input name': '請輸入名稱',
@@ -318,23 +318,23 @@ module.exports = {
 
   'Enter query conditions to filter': '輸入查詢條件進行過濾',
 
-  DELETE_TITLE: '{type}刪除確認?',
+  DELETE_TITLE: '{type} 刪除確認？',
   DELETE_TIP:
-    '確定刪除{type} <strong>{resource}</strong> ? {type}刪除後將無法恢復。',
+    '確定刪除 {type} <strong>{resource}</strong> ？ {type} 刪除後將無法恢復。',
   DELETE_CONFIRM_TIP:
-    '請輸入{type}名稱 <strong>{resource}</strong> 確保您已了解操作所带來的風險。',
+    '請輸入 {type} 名稱 <strong>{resource}</strong> 確保您已了解操作所帶來的風險。',
   DELETE_APP_RESOURCE_TIP:
-    '資源被應用 <strong>{app}</strong> 管理, 刪除後可能影響此應用的正常使用。請輸入{type}名稱 <strong>{resource}</strong> 確保您已了解操作所带來的風險。',
-  DELETE_CONFIRM_PLACEHOLDER: '請輸入{resource}',
+    '資源被應用 <strong>{app}</strong> 管理, 刪除後可能影響此應用的正常使用。請輸入 {type }名稱 <strong>{resource}</strong> 確保您已了解操作所帶來的風險。',
+  DELETE_CONFIRM_PLACEHOLDER: '請輸入 {resource}',
 
-  REMOVE_USER_TIP: '確定移除用戶 <strong>{username}</strong> ? ',
+  REMOVE_USER_TIP: '確定移除用戶 <strong>{username}</strong> ？',
 
-  REMOVE_MEMBER_TIP: '確定移除成員 <strong>{resource}</strong> ?',
+  REMOVE_MEMBER_TIP: '確定移除成員 <strong>{resource}</strong> ？',
 
-  REMOVE_GROUP_TIP: '確定移除組織 <strong>{resource}</strong> ?',
+  REMOVE_GROUP_TIP: '確定移除組織 <strong>{resource}</strong> ？',
 
-  DESTROY_TITLE: '確認銷毀?',
-  DESTROY_TIP: '確定銷毀{type} <strong>{resource}</strong> ?',
+  DESTROY_TITLE: '確認銷毀？',
+  DESTROY_TIP: '確定銷毀 {type} <strong>{resource}</strong> ？',
 
   'Error Tips': '錯誤提示',
 
@@ -483,7 +483,7 @@ module.exports = {
   'Not running yet': '未運行',
   successful: '成功',
   Tag: '標籤',
-  PATTERN_NAME_INVALID_TIP: '名稱不合法 （僅支持小寫字母、數字、底線）',
+  PATTERN_NAME_INVALID_TIP: '名稱不合法（僅支持小寫字母、數字、底線）',
   'No resources matching the filter have been found yet':
     '暫時没有找到符合過濾條件的資源',
   'You can try to': '您可以嘗試',
@@ -506,7 +506,7 @@ module.exports = {
   CODE_CONTRIBUTE: '貢獻代碼',
   GITHUB_STAR: '點亮Star',
 
-  CONDITION_STATUS_ANALYSE: '狀態分析(Conditions)',
+  CONDITION_STATUS_ANALYSE: '狀態分析 (Conditions)',
 
   NAV_PROJECTS: '項目管理',
   NAV_ACCOUNTS: '帳戶管理',


### PR DESCRIPTION
* The commit fixed some words ,sentences and typo for Traditional Chinese translations

Signed-off-by: ydFu <ader.ydfu@gmail.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

> /kind optimization


**What this PR does / why we need it**:

* The commit fixed some words ,sentences and typo for Traditional Chinese translations

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
