### PR TITLE
Fix the field of basic-auth secret

### DIFF
--- a/src/stores/devops/scm.js
+++ b/src/stores/devops/scm.js
@@ -216,7 +216,7 @@ export default class SCMStore extends BaseStore {
         [CREDENTIAL_DISPLAY_KEY['basic-auth']]: {
           id: this.githubCredentialId,
           password: token,
-          login: 'github',
+          username: 'github',
         },
       }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
basic-auth secret corresponding to usernamePassword credential in Jenkins, so the fields should be username and password

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
None.

