### PR TITLE
Add a multi-stage dockerfile to build console

### DIFF
--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -1,0 +1,19 @@
+FROM node:12.18 as builder
+
+WORKDIR /opt/kubesphere/console
+COPY console.tar.gz .
+RUN tar xzf console.tar.gz
+RUN yarn config set registry https://registry.npm.taobao.org
+RUN yarn
+RUN yarn build
+
+FROM node:12-alpine
+RUN adduser -D -g kubesphere -u 1002 kubesphere && \
+    mkdir -p /opt/kubesphere/console && \
+    chown -R kubesphere:kubesphere /opt/kubesphere/console
+WORKDIR /opt/kubesphere/console
+COPY --from=builder /opt/kubesphere/console /opt/kubesphere/console
+RUN mv dist/server.js server/server.js
+USER kubesphere
+EXPOSE 8000
+CMD ["npm", "run", "serve"]

--- a/Dockerfile.multistage
+++ b/Dockerfile.multistage
@@ -3,7 +3,6 @@ FROM node:12.18 as builder
 WORKDIR /opt/kubesphere/console
 COPY console.tar.gz .
 RUN tar xzf console.tar.gz
-RUN yarn config set registry https://registry.npm.taobao.org
 RUN yarn
 RUN yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+REPO?=kubespheredev/ks-console
+TAG:=$(shell git rev-parse --abbrev-ref HEAD)-dev
+
 setup:
 	docker volume create nodemodules
 
@@ -12,3 +15,10 @@ build:
 
 yarn-%:
 	docker-compose -f docker-compose.builder.yaml run --rm base yarn $*
+
+image:
+	rm -rf build && mkdir -p build
+	tar --exclude=".git" --exclude='node_modules' --exclude='build' --warning=no-file-changed -czf build/console.tar.gz .
+	docker build build -t $(REPO):$(TAG) -f Dockerfile.multistage
+image-push:
+	docker push $(REPO):$(TAG)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ Test KubeSphere console image by run:
 ./docker-run
 ```
 
+
+### Build KubeSphere Console Docker Image
+
+If you don't have NodeJs environment, it's also easy to build the Docker image:
+
+`make image image-push -e REPO=kubespheredev/ks-console`
+
+> Please replace the dockerHub repository to your personal account.
+
 ## Development Workflow
 
 Follow [Development Workflow](/docs/development-workflow.md) to commit your codes.


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For some users who might don't have the NodeJs environment, it's not easy to build KubeSphere Console. So I provide a multi-stage Dockerfile, people just need to have a Docker environment.

**Which issue(s) this PR fixes**:
None.

**Special notes for reviewers**:
None.

**Additional documentation, usage docs, etc.**:
I already added the related document in the README file.
