### PR TITLE
fix: Fix the webhook url in the single cluster

### DIFF
--- a/src/components/Forms/Pipelines/AdvanceSettings/index.jsx
+++ b/src/components/Forms/Pipelines/AdvanceSettings/index.jsx
@@ -78,16 +78,14 @@ export default class AdvanceSettings extends React.Component {
     const owner = get(formTemplate, `${this.scmPrefix}.owner`, '')
     const repo = get(formTemplate, `${this.scmPrefix}.repo`, '')
     const bitbucket_url = `${api_uri}/scm/${owner}/${repo}.git`
-    const cluster = get(formTemplate, 'cluster')
-    const clusterUrl = cluster ? `cluster/${cluster}/` : ''
 
     switch (this.sourceType) {
       case 'bitbucket_server':
-        return `${window.location.protocol}//${window.location.host}/${clusterUrl}devops_webhook/git/?url=${bitbucket_url}`
+        return `${window.location.protocol}//${window.location.host}/devops_webhook/git/?url=${bitbucket_url}`
       case 'github':
-        return `${window.location.protocol}//${window.location.host}/${clusterUrl}devops_webhook/${this.sourceType}/`
+        return `${window.location.protocol}//${window.location.host}/devops_webhook/${this.sourceType}/`
       default:
-        return `${window.location.protocol}//${window.location.host}/${clusterUrl}devops_webhook/git/?url=${url}`
+        return `${window.location.protocol}//${window.location.host}/devops_webhook/git/?url=${url}`
     }
   }
 


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu_5@163.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

 /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #[#kubesphere/kubesphere/3857](https://github.com/kubesphere/kubesphere/issues/3857)

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @LinuxSuRen 

