### PR TITLE
fix: rename the button 'Rerun' to 'Run' on the b2i page #1543

### DIFF
--- a/src/pages/projects/containers/ImageBuilder/Detail/index.jsx
+++ b/src/pages/projects/containers/ImageBuilder/Detail/index.jsx
@@ -91,8 +91,8 @@ export default class ImageBuilderDetail extends React.Component {
 
   getOperations = () => [
     {
-      key: 'reRun',
-      text: t('Rerun'),
+      key: 'Run',
+      text: t('run'),
       action: 'edit',
       type: 'control',
       onClick: () =>


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
rename the button 'Rerun' to 'Run' on the b2i page #1543

**Which issue(s) this PR fixes**:
Fixes  #1543


