### PR TITLE
fix: Content is reset while editing credential with kubeconfig

### DIFF
--- a/src/components/Modals/CredentialCreate/index.jsx
+++ b/src/components/Modals/CredentialCreate/index.jsx
@@ -65,7 +65,7 @@ export default class CredentialModal extends React.Component {
   }
 
   componentDidMount() {
-    if (this.type === 'kubeconfig') {
+    if (this.type === 'kubeconfig' && !this.props.isEditMode) {
       this.fetchKubeConfig()
     }
   }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu_5@163.com>

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

 /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##1907

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @JohnNiang 