### PR TITLE
fix: Modify system workspace rules control to show a web terminal on container of system-workspace

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -460,7 +460,7 @@ client:
   systemWorkspaceRules:
     devops: []
     members: [manage]
-    projects: [view, edit]
+    projects: [view, edit, manage]
     roles: [view]
     workspaces: [view, edit]
   systemWorkspaceProjectRules:


### PR DESCRIPTION

Signed-off-by: lannyfu <lannyfu@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The reason why a web terminal can't be displayed on the system-workspace is because the projects are only allowed to edit and view , so I did this change

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##1915

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:
![image](https://user-images.githubusercontent.com/63338728/119758476-31588e80-bed9-11eb-93d9-9c557067a9c2.png)
![image](https://user-images.githubusercontent.com/63338728/119758669-7a104780-bed9-11eb-9fc8-f6a50f9fad52.png)


<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
