### PR TITLE
fix: Set the first app template to default.

### DIFF
--- a/src/components/Forms/Dashboard/BaseInfo/index.jsx
+++ b/src/components/Forms/Dashboard/BaseInfo/index.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react'
 import { observer } from 'mobx-react'
-import { get, set } from 'lodash'
+import { get, set, isEmpty } from 'lodash'
 import { Column, Columns, Form, Input, TextArea } from '@kube-design/components'
 import CardSelect from 'components/Inputs/CardSelect'
 import { PATTERN_NAME, MODULE_KIND_MAP } from 'utils/constants'
@@ -28,6 +28,16 @@ import styles from './index.scss'
 
 @observer
 export default class BaseInfo extends React.Component {
+  constructor(props) {
+    super(props)
+
+    if (isEmpty(this.formTemplate.spec)) {
+      const defaultKey = Object.keys(templateSettings)[0]
+      const defaultValue = templateSettings[defaultKey].settings
+      set(this.formTemplate, 'spec', defaultValue)
+    }
+  }
+
   get formTemplate() {
     const { formTemplate, module } = this.props
     return get(formTemplate, MODULE_KIND_MAP[module], formTemplate)


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Referring to the Create Storage Class Modal, I set the first app template to be selected by default

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #[#kubesphere/kubesphere/3734](https://github.com/kubesphere/kubesphere/issues/3734)

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:
![image](https://user-images.githubusercontent.com/63338728/121308928-2fa8b500-c934-11eb-81b2-742127e4cdcc.png)
![image](https://user-images.githubusercontent.com/63338728/121308984-3c2d0d80-c934-11eb-8a9a-2ceb45165ddf.png)

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
