### PR TITLE
fix: Modify the validation rules for the input box on the alerting policy page

### DIFF
--- a/locales/en/alerting.js
+++ b/locales/en/alerting.js
@@ -87,6 +87,7 @@ module.exports = {
   'Rule Templates': 'Rule Templates',
   'Custom Rule': 'Custom Rule',
   'Rule Expression': 'Rule Expression',
+  'Invalid time': 'Invalid time',
 
   'Please input the rule expression': 'Please input the rule expression',
 

--- a/locales/es/alerting.js
+++ b/locales/es/alerting.js
@@ -88,6 +88,7 @@ module.exports = {
   'Rule Templates': 'Rule Templates',
   'Custom Rule': 'Custom Rule',
   'Rule Expression': 'Rule Expression',
+  'Invalid time': 'Tiempo inválido',
 
   'Please input the rule expression': 'Please input the rule expression',
 

--- a/locales/tc/alerting.js
+++ b/locales/tc/alerting.js
@@ -113,6 +113,7 @@ module.exports = {
   'Rule Templates': '規則模版',
   'Custom Rule': '自定義規則',
   'Rule Expression': '告警規則表達式',
+  'Invalid time': '時間格式錯誤',
 
   'Please input the rule expression': '请输入告警規則表達式',
 

--- a/locales/zh/alerting.js
+++ b/locales/zh/alerting.js
@@ -59,6 +59,7 @@ module.exports = {
   'Rule Templates': '规则模板',
   'Custom Rule': '自定义规则',
   'Rule Expression': '告警规则表达式',
+  'Invalid time': '时间格式错误',
 
   'Please input the rule expression': '请输入告警规则表达式',
 

--- a/src/components/Forms/AlertingPolicy/BaseInfo/index.jsx
+++ b/src/components/Forms/AlertingPolicy/BaseInfo/index.jsx
@@ -93,6 +93,14 @@ export default class BaseInfo extends React.Component {
       })
   }
 
+  timeValidator = (rule, value, callback) => {
+    const time = /^[0-9]*$/
+    if (!time.test(value.slice(0, -1))) {
+      return callback({ message: t('Invalid time') })
+    }
+    callback()
+  }
+
   render() {
     const { isEdit, formRef, formTemplate } = this.props
     const rules = isEdit
@@ -134,6 +142,7 @@ export default class BaseInfo extends React.Component {
             <Form.Item
               label={`${t('Alerting Duration')}(${t('Minutes')})`}
               desc={t('ALERTING_DURATION')}
+              rules={[{ validator: this.timeValidator }]}
             >
               <UnitWrapper name="duration" unit="m">
                 <Select options={this.durationOptions} searchable />

--- a/src/configs/alerting/metrics/rule.config.js
+++ b/src/configs/alerting/metrics/rule.config.js
@@ -82,7 +82,11 @@ export const getBaseRuleConfig = ({ condition = {}, thresholds = {} } = {}) => [
   },
 ]
 
-export const BASE_RULE_CONFIG = getBaseRuleConfig()
+export const BASE_RULE_CONFIG = getBaseRuleConfig({
+  thresholds: {
+    min: 0,
+  },
+})
 
 export const PERCENT_RULE_CONFIG = getBaseRuleConfig({
   thresholds: {


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
1.Set the alarm duration to a pure number.
2.Set the min value for ```cpu average load(1m 5m 15m)/iops``` .

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #[#kubesphere/kubesphere/3755](https://github.com/kubesphere/kubesphere/issues/3755)

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:
![image](https://user-images.githubusercontent.com/63338728/121647291-d58d2880-cac8-11eb-9f0f-0421021fba80.png)

https://user-images.githubusercontent.com/63338728/121646764-38ca8b00-cac8-11eb-8087-92dd284d8069.mov


<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
