### PR TITLE
Force pull base image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build image
       if: github.event_name == 'push'
-      run: docker build . --file Dockerfile --tag $IMAGE_NAME
+      run: docker build  --pull --file Dockerfile --tag $IMAGE_NAME  . 
 
     - name: Docker login
       if: github.event_name == 'push'


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
 /kind optimization

**What this PR does / why we need it**:
Use the `--pull` option in the `docker build` command to prevent the docker image cache. So we can update the Alpine base image with the latest fixes.