### PR TITLE
yarn.lock file isn't required by runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,3 @@
 !dist
 !server/(locales|public|sample|views|config.yaml)
 !package.json
-!yarn.lock


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@yunify.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove yarn.lock file from the docker image.
There are some false positive CVE issues were reported by the scaner, which try to detect issues with the yarn.lock file. But some of those packages were not compiled into the release.

**Which issue(s) this PR fixes**:

Fixes #

