### PR TITLE
fix: Service monitor is not associated when service is viewed and deleted

### DIFF
--- a/src/actions/service.js
+++ b/src/actions/service.js
@@ -234,6 +234,15 @@ export default {
             namespace,
           })
 
+          set(data, 'metadata.ownerReferences', [
+            {
+              apiVersion: 'v1',
+              kind: 'Service',
+              name: detail.name,
+              uid: detail.uid,
+            },
+          ])
+
           if (!result.exist) {
             await serviceMonitorStore.create(data, { cluster, namespace })
           } else if (isEmpty(get(data, 'spec.endpoints'))) {

--- a/src/pages/projects/components/Cards/ServiceMonitors/index.jsx
+++ b/src/pages/projects/components/Cards/ServiceMonitors/index.jsx
@@ -52,13 +52,13 @@ export default class ServiceMonitors extends React.Component {
   }
 
   getData = () => {
-    const { cluster, namespace, service } = this.props
+    const { cluster, namespace, labels } = this.props
 
-    if (!isEmpty(service)) {
+    if (!isEmpty(labels)) {
       this.store.fetchListByK8s({
         cluster,
         namespace,
-        labelSelector: joinSelector({ app: service }),
+        labelSelector: joinSelector(labels),
       })
     }
   }

--- a/src/pages/projects/components/Cards/ServiceMonitors/index.jsx
+++ b/src/pages/projects/components/Cards/ServiceMonitors/index.jsx
@@ -52,12 +52,13 @@ export default class ServiceMonitors extends React.Component {
   }
 
   getData = () => {
-    const { selector, cluster, namespace } = this.props
-    if (!isEmpty(selector)) {
+    const { cluster, namespace, service } = this.props
+
+    if (!isEmpty(service)) {
       this.store.fetchListByK8s({
         cluster,
         namespace,
-        labelSelector: joinSelector(selector),
+        labelSelector: joinSelector({ app: service }),
       })
     }
   }

--- a/src/pages/projects/containers/Services/Detail/ResourceStatus/index.jsx
+++ b/src/pages/projects/containers/Services/Detail/ResourceStatus/index.jsx
@@ -111,7 +111,7 @@ export default class ResourceStatus extends React.Component {
 
   renderServiceMonitors() {
     const store = this.props.serviceMonitorStore
-    const { cluster, namespace, selector } = this.store.detail
+    const { cluster, namespace, selector, name } = this.store.detail
 
     if (isEmpty(selector)) {
       return null
@@ -119,9 +119,9 @@ export default class ResourceStatus extends React.Component {
 
     return (
       <ServiceMonitors
-        selector={selector}
         cluster={cluster}
         namespace={namespace}
+        service={name}
         store={store}
       />
     )

--- a/src/pages/projects/containers/Services/Detail/ResourceStatus/index.jsx
+++ b/src/pages/projects/containers/Services/Detail/ResourceStatus/index.jsx
@@ -111,7 +111,7 @@ export default class ResourceStatus extends React.Component {
 
   renderServiceMonitors() {
     const store = this.props.serviceMonitorStore
-    const { cluster, namespace, selector, name } = this.store.detail
+    const { cluster, namespace, selector, labels } = this.store.detail
 
     if (isEmpty(selector)) {
       return null
@@ -121,7 +121,7 @@ export default class ResourceStatus extends React.Component {
       <ServiceMonitors
         cluster={cluster}
         namespace={namespace}
-        service={name}
+        labels={labels}
         store={store}
       />
     )

--- a/src/pages/projects/containers/Services/Detail/index.jsx
+++ b/src/pages/projects/containers/Services/Detail/index.jsx
@@ -75,12 +75,13 @@ export default class ServiceDetail extends React.Component {
   }
 
   fetchServiceMonitors = () => {
-    const { selector, cluster, namespace } = this.store.detail
-    if (!isEmpty(selector)) {
+    const { cluster, namespace, name } = this.store.detail
+
+    if (!isEmpty(name)) {
       this.serviceMonitorStore.fetchListByK8s({
         cluster,
         namespace,
-        labelSelector: joinSelector(selector),
+        labelSelector: joinSelector({ app: name }),
       })
     }
   }

--- a/src/pages/projects/containers/Services/Detail/index.jsx
+++ b/src/pages/projects/containers/Services/Detail/index.jsx
@@ -75,13 +75,13 @@ export default class ServiceDetail extends React.Component {
   }
 
   fetchServiceMonitors = () => {
-    const { cluster, namespace, name } = this.store.detail
+    const { cluster, namespace, labels } = this.store.detail
 
-    if (!isEmpty(name)) {
+    if (!isEmpty(labels)) {
       this.serviceMonitorStore.fetchListByK8s({
         cluster,
         namespace,
-        labelSelector: joinSelector({ app: name }),
+        labelSelector: joinSelector(labels),
       })
     }
   }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu_5@163.com>

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #[#kubesphere/kubesphere/3992](https://github.com/kubesphere/kubesphere/issues/3992) #[#kubesphere/kubesphere/3993](https://github.com/kubesphere/kubesphere/issues/3993)

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @junotx 
