### PR TITLE
--export is deprecated on kubectl:v1.19.8, use kubectl neat instead

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -89,7 +89,7 @@ jobs:
           password: ${{ secrets.QING_PASSWORD }}
           port: 22
           script: |
-            kubectl -n kubesphere-system get deploy ks-console --export -o yaml | sed "s/kubespheredev\/ks-console:latest/kubespheredev\/${{ env.IMAGE_NAME }}/g" | sed "s/app:\ ks-console/app:\ ${{ env.SERVICE_NAME }}/g" | sed "0,/name:\ ks-console/{s/name:\ ks-console/name:\ ${{ env.SERVICE_NAME }}/}" | kubectl apply -n kubesphere-system -f -
+            kubectl -n kubesphere-system get deploy ks-console -o yaml | kubectl neat | sed "s/kubespheredev\/ks-console:latest/kubespheredev\/${{ env.IMAGE_NAME }}/g" | sed "s/app:\ ks-console/app:\ ${{ env.SERVICE_NAME }}/g" | sed "0,/name:\ ks-console/{s/name:\ ks-console/name:\ ${{ env.SERVICE_NAME }}/}" | kubectl apply -n kubesphere-system -f -
 
             kubectl -n kubesphere-system rollout restart deploy ${{ env.SERVICE_NAME }}
             kubectl -n kubesphere-system expose deploy ${{ env.SERVICE_NAME }} --type=NodePort --port=80 --target-port=8000


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
PR deploy is failing, because kubectl --export is deprecated on version 1.19.8, update workflow yaml with `kubectl neat`

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
