### PR TITLE
Fix the incorrect tag of CI auto-push image

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,8 +61,6 @@ jobs:
           IMAGE_ID=$DOCKERHUB_REPO/$IMAGE_NAME
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
           [ "$VERSION" == "dev" ] && VERSION=dev


### PR DESCRIPTION
Signed-off-by: Zhengyi Lai <zheng1@kubesphere.io>

**What type of PR is this?**
/kind optimization

**What this PR does / why we need it**:
The image tag previously built from the tag is `3.1.1-rc.0`, the correction should be `v3.1.1-rc.0`
