### PR TITLE
fix: Modify the width of marks and let words not be squeezed

### DIFF
--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -163,7 +163,7 @@ export default class ResourceLimit extends React.Component {
         { value: 0, label: t('No Request'), weight: 2 },
         { value: 0.2, label: 0.2, weight: 2 },
         { value: 0.5, label: 0.5, weight: 2 },
-        { value: 1, label: 1, weight: 3 },
+        { value: 1, label: 1, weight: 2 },
         { value: 2, label: 2, weight: 2 },
         { value: 3, label: 3, weight: 2 },
         { value: 4, label: 4 },
@@ -182,8 +182,8 @@ export default class ResourceLimit extends React.Component {
     return {
       marks: [
         { value: 0, label: t('No Request'), weight: 2 },
-        { value: 200, label: 200, weight: 2 },
-        { value: 500, label: 500, weight: 2 },
+        { value: 200, label: 200, weight: 1 },
+        { value: 500, label: 500, weight: 1 },
         { value: 1000, label: 1000, weight: 2 },
         { value: 2000, label: 2000, weight: 2 },
         { value: 4000, label: 4000, weight: 2 },


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

**What type of PR is this?**
 /kind bug
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##1224

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:
![image](https://user-images.githubusercontent.com/63338728/124409564-249e4480-dd7b-11eb-9aea-889f842a97a9.png)
![image](https://user-images.githubusercontent.com/63338728/124409710-64fdc280-dd7b-11eb-810b-4e9060dcb755.png)


<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
