### PR TITLE
fix: Container logs do not display full Spaces.

### DIFF
--- a/src/components/Cards/ContainerLog/index.scss
+++ b/src/components/Cards/ContainerLog/index.scss
@@ -53,6 +53,7 @@
     color: #b7c4d1;
     font-weight: 600;
     line-height: 20px;
+    white-space: pre;
 
     strong {
       color: $yellow;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Display log contents correctly.

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

| before | After |
| ------ | ----- |
|    <img width="2007" alt="Snipaste_2021-07-12_23-41-44" src="https://user-images.githubusercontent.com/21301288/125317394-8e19e680-e36b-11eb-8f60-37e74bca0cea.png"> |  <img width="2009" alt="Snipaste_2021-07-12_23-41-26" src="https://user-images.githubusercontent.com/21301288/125317444-970ab800-e36b-11eb-825a-cec6fe7dd286.png"> |
|   <img width="2007" alt="Snipaste_2021-07-12_23-46-58" src="https://user-images.githubusercontent.com/21301288/125317483-9e31c600-e36b-11eb-97e7-b36e0951fa24.png"> |  <img width="2008" alt="Snipaste_2021-07-12_23-46-45" src="https://user-images.githubusercontent.com/21301288/125317469-9bcf6c00-e36b-11eb-8965-1881eb0646eb.png"> |
