### PR TITLE
fix: Fix 'About' window can't be closed automatically

### DIFF
--- a/src/components/Modals/About/index.jsx
+++ b/src/components/Modals/About/index.jsx
@@ -42,6 +42,7 @@ export default class AboutModal extends Component {
         width={600}
         hideHeader
         hideFooter
+        maskClosable
         {...this.props}
       >
         <div className={styles.describtion}>


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
To fix 'About' window can't be closed automatically when moving mouse and clicking out of 'About' window

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2110
### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
let 'About' window can be closed automatically
```
**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

https://user-images.githubusercontent.com/63338728/126419630-ae5edbb4-424c-4f1a-93b9-689f26653144.mov


<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
