### PR TITLE
update pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,54 @@
-**What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
->
-> /kind api-change
-> /kind bug
-> /kind optimization
-> /kind cleanup
-> /kind design
-> /kind documentation
-> /kind failing-test
-> /kind feature
+<!-- Thanks for sending a pull request! Here are some tips for you:
 
-**What this PR does / why we need it**:
+1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
+2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
+3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
+-->
 
-**Which issue(s) this PR fixes**:
+### What type of PR is this?
+<!-- 
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+
+### What this PR does / why we need it:
+
+### Which issue(s) this PR fixes:
 <!--
 Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
 _If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
 -->
 Fixes #
 
-**Special notes for reviewers**:
+### Special notes for reviewers:
 ```
 ```
 
-**Additional documentation, usage docs, etc.**:
+### Does this PR introduced a user-facing change?
+<!--
+If no, just write "None" in the release-note block below.
+If yes, a release note is required:
+Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
 
+For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
+-->
+```release-note
+
+```
+
+### Additional documentation, usage docs, etc.:
 <!--
 This section can be blank if this pull request does not require a release note.
 Please use the following format for linking documentation or pass the


### PR DESCRIPTION
### What type of PR is this?
 /kind documentation

### What this PR does / why we need it:
We are adopting more features of Prow,  need to align `PULL_REQUEST_TEMPLATE` with Kubernetes. It's more friendly. `release-note` section is required after, every PR author is responsible for writing readable `release note` if it introduces user facing changes. Otherwise, just write `None`

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
```release-notes
None
```
