### PR TITLE
fix: enter a number with two places of decimal directly and limit input maximum

### DIFF
--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -68,13 +68,23 @@ export default {
           }
 
           const spec = get(data, 'spec.hard', {})
-
-          for (const key in spec) {
-            if (spec[key] === Infinity) {
+          const units = ['ki', 'mi', 'gi', 'ti']
+          Object.keys(spec).forEach(key => {
+            const value = spec[key]
+            if (value === Infinity) {
               spec[key] = ''
             }
-          }
-
+            if (!value) {
+              return
+            }
+            if (value.slice(-1) === '.') {
+              spec[key] = value.slice(0, -1)
+            }
+            const keyUnit = value.slice(-2).toLowerCase()
+            if (value.slice(-3, -2) === '.' && units.indexOf(keyUnit) > -1) {
+              spec[key] = `${value.slice(0, -3)}${value.slice(-2)}`
+            }
+          })
           data.spec = {
             hard: omitBy(spec, v => (!v ? !v : isEmpty(v.toString()))),
           }

--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -68,16 +68,12 @@ export default {
           }
 
           const spec = get(data, 'spec.hard', {})
-
-          for (const key in spec) {
-            if (spec[key] === Infinity) {
-              spec[key] = ''
-            }
-          }
-
           const units = ['ki', 'mi', 'gi', 'ti']
           Object.keys(spec).forEach(key => {
             const value = spec[key]
+            if (value === Infinity) {
+              spec[key] = ''
+            }
             if (!isString(value)) {
               return
             }

--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, set, omitBy, isEmpty } from 'lodash'
+import { get, set, omitBy, isEmpty, isString } from 'lodash'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
 import QuotaEditModal from 'components/Modals/QuotaEdit'
@@ -68,13 +68,17 @@ export default {
           }
 
           const spec = get(data, 'spec.hard', {})
+
+          for (const key in spec) {
+            if (spec[key] === Infinity) {
+              spec[key] = ''
+            }
+          }
+
           const units = ['ki', 'mi', 'gi', 'ti']
           Object.keys(spec).forEach(key => {
             const value = spec[key]
-            if (value === Infinity) {
-              spec[key] = ''
-            }
-            if (!value) {
+            if (!isString(value)) {
               return
             }
             if (value.slice(-1) === '.') {
@@ -85,6 +89,7 @@ export default {
               spec[key] = `${value.slice(0, -3)}${value.slice(-2)}`
             }
           })
+
           data.spec = {
             hard: omitBy(spec, v => (!v ? !v : isEmpty(v.toString()))),
           }

--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -80,11 +80,17 @@ export default class ResourceLimit extends React.Component {
     return null
   }
 
-  static allowInputDot(formatNum, unit, dotIndex, formatFn) {
-    if (formatNum && formatNum.slice(...dotIndex) === '.') {
+  static allowInputDot(formatNum, unit, formatFn, isMemory = false) {
+    const inputNum = formatNum && isMemory ? formatNum.slice(0, -2) : formatNum
+    if (inputNum && inputNum.endsWith('.')) {
       const number = formatFn(formatNum, unit)
       return `${number}.`
     }
+    if (inputNum && inputNum.endsWith('.0')) {
+      const number = formatFn(formatNum, unit)
+      return `${number}.0`
+    }
+
     return formatFn(formatNum, unit)
   }
 
@@ -95,29 +101,27 @@ export default class ResourceLimit extends React.Component {
     const cpuRequests = ResourceLimit.allowInputDot(
       ResourceLimit.getDefaultRequestValue(props, 'cpu'),
       cpuUnit,
-      [-1],
       cpuFormat
     )
 
     const cpuLimits = ResourceLimit.allowInputDot(
       ResourceLimit.getDefaultLimitValue(props, 'cpu'),
       cpuUnit,
-      [-1],
       cpuFormat
     )
 
     const memoryRequests = ResourceLimit.allowInputDot(
       ResourceLimit.getDefaultRequestValue(props, 'memory'),
       memoryUnit,
-      [-3, -2],
-      memoryFormat
+      memoryFormat,
+      true
     )
 
     const memoryLimits = ResourceLimit.allowInputDot(
       ResourceLimit.getDefaultLimitValue(props, 'memory'),
       memoryUnit,
-      [-3, -2],
-      memoryFormat
+      memoryFormat,
+      true
     )
 
     return {

--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -240,11 +240,19 @@ export default class ResourceLimit extends React.Component {
     let memoryError = ''
     const { requests, limits } = state
 
-    if (limits.cpu && Number(requests.cpu) > Number(limits.cpu)) {
+    if (
+      limits.cpu &&
+      !String(limits.cpu).endsWith('.') &&
+      Number(requests.cpu) > Number(limits.cpu)
+    ) {
       cpuError = 'RequestExceed'
     }
 
-    if (limits.memory && Number(requests.memory) > Number(limits.memory)) {
+    if (
+      limits.memory &&
+      !String(limits.memory).endsWith('.') &&
+      Number(requests.memory) > Number(limits.memory)
+    ) {
       memoryError = 'RequestExceed'
     }
 
@@ -320,7 +328,6 @@ export default class ResourceLimit extends React.Component {
     let inputNum
     const name = e.target.name
     const maxiNum = this.getInputMaxiNum(name)
-
     if (value === '') {
       inputNum = 0
     } else if (value > maxiNum) {

--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -298,13 +298,32 @@ export default class ResourceLimit extends React.Component {
     )
   }
 
+  getInputMaxiNum(name) {
+    let maxiNum
+    if (this.props.cpuProps) {
+      if (name.indexOf('cpu')) {
+        const marks = this.props.cpuProps.marks
+        maxiNum = marks[marks.length - 2].value
+      } else if (name.indexOf('memory')) {
+        const memoryMarks = this.props.memoryProps.marks
+        maxiNum = memoryMarks[memoryMarks.length - 2].value
+      }
+    } else if (name.indexOf('cpu')) {
+      maxiNum = 4
+    } else if (name.indexOf('memory')) {
+      maxiNum = 8000
+    }
+    return maxiNum
+  }
+
   handleInputChange = (e, value) => {
     let inputNum
     const name = e.target.name
+    const maxiNum = this.getInputMaxiNum(name)
 
     if (value === '') {
       inputNum = 0
-    } else if (value > 1000) {
+    } else if (value > maxiNum) {
       value = 'infinity'
     } else {
       const number = /^(([1-9]{1}\d*)|(0{1}))(\.\d{0,2})?$/.exec(value)


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2102

### Special notes for reviewers:
(1) now, we can enter a number with two places of decimal, eg: 0.02, 3.23.

https://user-images.githubusercontent.com/33231138/127299025-64cb4586-7486-4b96-b6e1-664398ae7ef8.mov

(2) we can not input a number bigger than 8, the maximum is from the props, it 's default value is 4(cpu)/8000(memory)

https://user-images.githubusercontent.com/33231138/127299064-87ec9fd8-f47e-4b1d-bf7f-a394c3bb3b79.mov

### Additional documentation, usage docs, etc.:

### Does this PR introduced a user-facing change?

```release-note
fix: enter a number with two places of decimal directly and limit input maximum. (#2102, @weili520  )
```