### PR TITLE
fix: Fix the cursor of project's Selector

### DIFF
--- a/src/pages/projects/components/Selector/index.scss
+++ b/src/pages/projects/components/Selector/index.scss
@@ -7,6 +7,7 @@
   padding: 12px;
   border-radius: $border-radius;
   background-color: #242e42;
+  cursor: pointer;
   box-shadow: 0 8px 16px 0 rgba(36, 46, 66, 0.2);
 
   .icon {


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 





Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2080

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
show cursor on project's Selector
```

### Additional documentation, usage docs, etc.:
![image](https://user-images.githubusercontent.com/63338728/127304496-b7b3e45b-ed08-49da-9c95-4199c699caff.png)

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
