### PR TITLE
fix: disallow user zoom out below 75% in safari browser

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -51,6 +51,17 @@ window.onunhandledrejection = function(e) {
   }
 }
 
+// handle safari browser zoom out too small
+window.onresize = () => {
+  const ratio = window.outerHeight / window.innerHeight
+  const ua = navigator.userAgent.toLowerCase()
+  if (ua.indexOf('safari') && ratio < 0.75) {
+    document.body.style.zoom = 1.5
+  } else {
+    document.body.style.zoom = 1
+  }
+}
+
 window.t = i18n.t
 window.request = request
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <1512298456@qq.com>

### What type of PR is this?
/kind bug


### What this PR does / why we need it:


### Which issue(s) this PR fixes:
Fixes ##1962

### Special notes for reviewers:
this bug maybe caused by  safari zoom mechanism, see more: [Safari zoom in/out ruins page layout (doesn't change font-size well)](https://stackoverflow.com/questions/8038876/safari-zoom-in-out-ruins-page-layout-doesnt-change-font-size-well/8457784#8457784)

https://user-images.githubusercontent.com/33231138/127466770-efa248e5-dcf8-443a-85e6-049df563491d.mov

```release-note
NONE
```