### PR TITLE
fix:  Pipeline editor cant save init value

### DIFF
--- a/src/pages/devops/components/Pipeline/StepModals/script.jsx
+++ b/src/pages/devops/components/Pipeline/StepModals/script.jsx
@@ -45,7 +45,7 @@ export default class Shell extends React.Component {
 
   static getDerivedStateFromProps(nextProps) {
     if (nextProps.edittingData.type === 'script') {
-      const value = get(nextProps.edittingData.data, '[0].value', '')
+      const value = get(nextProps.edittingData.data, '[0].value.value', '')
       return { value, initValue: value }
     }
     return null
@@ -63,7 +63,10 @@ export default class Shell extends React.Component {
       arguments: [
         {
           key: 'scriptBlock',
-          value: this.isInputed ? this.newValue : initValue,
+          value: {
+            isLiteral: true,
+            value: this.isInputed ? this.newValue : initValue,
+          },
         },
       ],
     })

--- a/src/pages/devops/components/Pipeline/StepModals/script.jsx
+++ b/src/pages/devops/components/Pipeline/StepModals/script.jsx
@@ -45,23 +45,25 @@ export default class Shell extends React.Component {
 
   static getDerivedStateFromProps(nextProps) {
     if (nextProps.edittingData.type === 'script') {
-      const value = get(nextProps.edittingData.data, '[0].value.value', '')
-      return { value }
+      const value = get(nextProps.edittingData.data, '[0].value', '')
+      return { value, initValue: value }
     }
     return null
   }
 
   handleChange = value => {
+    this.isInputed = true
     this.newValue = value
   }
 
   handleOk = () => {
+    const { initValue } = this.state
     this.props.onAddStep({
       name: 'script',
       arguments: [
         {
           key: 'scriptBlock',
-          value: { isLiteral: true, value: this.newValue || '' },
+          value: this.isInputed ? this.newValue : initValue,
         },
       ],
     })

--- a/src/pages/devops/components/Pipeline/StepModals/shell.jsx
+++ b/src/pages/devops/components/Pipeline/StepModals/shell.jsx
@@ -40,29 +40,34 @@ export default class Shell extends React.Component {
 
   constructor(props) {
     super(props)
+
     this.state = { value: '' }
   }
 
   static getDerivedStateFromProps(nextProps) {
     if (nextProps.edittingData.type === 'sh') {
       const value = get(nextProps.edittingData.data, '[0].value.value', '')
-
-      return { value }
+      return { value, initValue: value }
     }
     return null
   }
 
   handleChange = value => {
+    this.isInputed = true
     this.newValue = value
   }
 
   handleOk = () => {
+    const { initValue } = this.state
     this.props.onAddStep({
       name: 'sh',
       arguments: [
         {
           key: 'script',
-          value: { isLiteral: true, value: this.newValue || '' },
+          value: {
+            isLiteral: true,
+            value: this.isInputed ? this.newValue : initValue,
+          },
         },
       ],
     })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:
When the pipeline is edited again and no input is made, the initial value cannot be saved
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##https://github.com/kubesphere/kubesphere/issues/3950

### Special notes for reviewers:
<img width="317" alt="WeChat063a5f86da96bf4f4b628dcade59f3b7" src="https://user-images.githubusercontent.com/49010414/127950733-28c779be-c3ac-417a-91df-584c3aacb955.png">
<img width="336" alt="WeChat68682146e1ee42523c88fc7c7899538e" src="https://user-images.githubusercontent.com/49010414/127950739-3ae5db19-0d31-409b-a7ba-49f34bd2ecba.png">

```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
