### PR TITLE
fix: Detect UI text entries in different locale files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,9 @@
     "*.{json,css,scss}": [
       "prettier --write",
       "git add"
+    ],
+    "locales/**/*.js": [
+      "node scripts/checkRepeat.js"
     ]
   },
   "devDependencies": {

--- a/scripts/checkRepeat.js
+++ b/scripts/checkRepeat.js
@@ -1,0 +1,32 @@
+const fs = require('fs')
+
+const args = process.argv.slice(2)
+const filePath = args[0].split('locales')
+
+const lang = filePath[1].split('/')[1]
+const fileName = filePath[1].split('/')[2]
+var repeatArr = []
+const files = fs.readdirSync(`locales/${lang}`)
+const allKeyArr = []
+const thisFileObj = require(`../locales/${lang}/${fileName}`)
+
+files.forEach(file => {
+  if (file === 'index.js' || file === fileName) {
+    return
+  }
+  const fileObj = require(`../locales/${lang}/${file}`)
+  Object.keys(fileObj).forEach(key => {
+    allKeyArr.push(key)
+  })
+})
+
+Object.keys(thisFileObj).forEach(key => {
+  if (allKeyArr.indexOf(key) > -1) {
+    repeatArr.push(key)
+  }
+})
+  
+if(repeatArr.length>0) {
+  let errMessage  = `/locales/${lang}/${fileName}文件中存在以下重复UI词条：`+repeatArr
+  throw errMessage
+}

--- a/scripts/locale-plugin.js
+++ b/scripts/locale-plugin.js
@@ -19,6 +19,7 @@
 const fs = require('fs')
 const path = require('path')
 const RawSource = require('webpack-sources/lib/RawSource')
+const langArr = fs.readdirSync(`./locales/`)
 
 const isDev = process.env.NODE_ENV === 'development'
 
@@ -49,8 +50,35 @@ class LocalePlugin {
 
         compilation.updateAsset(asset.name, new RawSource(content))
       })
+      langArr.forEach(lang => {
+        only(lang)
+      })
     })
   }
+}
+
+function read(lang) {
+  const files = fs.readdirSync(`locales/${lang}`)
+  return files
+}
+
+function only(lang) {
+  const files = read(lang)
+
+  const allKeyArr = []
+  files.forEach(file => {
+    if (file === 'index.js') {
+      return
+    }
+    const fileObj = require(`../locales/${lang}/${file}`)
+    Object.keys(fileObj).forEach(key => {
+      if (allKeyArr.indexOf(key) > -1) {
+        console.log(lang, '语言环境下重复UI词条为:', key)
+      } else {
+        allKeyArr.push(key)
+      }
+    })
+  })
 }
 
 module.exports = LocalePlugin


### PR DESCRIPTION
Signed-off-by: lannyfu <lannyfu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

### What this PR does / why we need it:
To  detect UI text entries in different locale files after `yarn start` and `git commit`

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #[#kubesphere/issues/4125](https://github.com/kubesphere/kubesphere/issues/4125)

### Special notes for reviewers:
```
```
`yarn start`

https://user-images.githubusercontent.com/63338728/129128297-a3f17c6b-b62d-433e-afbd-3ee0d7c733b4.mov

`git commit`

https://user-images.githubusercontent.com/63338728/129128328-a083b66b-9301-48b7-9f01-8afdd110b454.mov



### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add feature about detecting UI text entries for duplication
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
