### PR TITLE
Improve the image tag name in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 REPO?=kubespheredev/ks-console
-TAG?=$(shell git rev-parse --abbrev-ref HEAD)-dev
+TAG?=$(shell git rev-parse --abbrev-ref HEAD | sed -e 's/\//-/g')-dev
 
 setup:
 	docker volume create nodemodules


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup

### What this PR does / why we need it:
Cannot get a correct image tag when the git tag name like `fix/xxx`. See also the following test result:

Before:
```
gitpod /workspace/console $ make image image-push
rm -rf build && mkdir -p build
tar --exclude=".git" --exclude='node_modules' --exclude='build' --warning=no-file-changed -czf build/console.tar.gz .
docker build build -t surenpi:bugfix/editor-cant-save-init-value-dev -f Dockerfile.multistage
invalid argument "surenpi:bugfix/editor-cant-save-init-value-dev" for "-t, --tag" flag: invalid reference format
See 'docker build --help'.
make: *** [Makefile:22: image] Error 125
```

After:
```
gitpod /workspace/console $ git checkout -b fix/image
Switched to a new branch 'fix/image'
gitpod /workspace/console $ make image
rm -rf build && mkdir -p build
tar --exclude=".git" --exclude='node_modules' --exclude='build' --warning=no-file-changed -czf build/console.tar.gz .
docker build build -t surenpi:fix-image-dev -f Dockerfile.multistage
```

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

### Special notes for reviewers:
```
None.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
