### PR TITLE
Update UI to support creating init container and mounting the volume …

### DIFF
--- a/src/components/Forms/Workload/VolumeSettings/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/index.jsx
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, set, unset, isUndefined, isEmpty } from 'lodash'
+import { concat, get, set, unset, isUndefined, isEmpty } from 'lodash'
 import React from 'react'
 import { toJS } from 'mobx'
 import { observer } from 'mobx-react'
@@ -214,12 +214,20 @@ class VolumeSettings extends React.Component {
       this.fedFormTemplate,
       `${this.prefix}spec.containers`,
       []
-    )
+    ).map(c => ({ ...c, type: 'worker' }))
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    ).map(c => ({ ...c, type: 'init' }))
 
+    const mergedContainers = concat(containers, initContainers)
     const volumes = get(this.fedFormTemplate, `${this.prefix}spec.volumes`, [])
 
     newVolumeMounts.forEach(({ containerName, volume, ...rest }) => {
-      const container = containers.find(item => item.name === containerName)
+      const container = mergedContainers.find(
+        item => item.name === containerName
+      )
       const existVolume = findVolume(volumes, volume)
 
       if (existVolume && container) {
@@ -248,7 +256,23 @@ class VolumeSettings extends React.Component {
       }
     })
 
-    set(this.fedFormTemplate, `${this.prefix}spec.containers`, containers)
+    const _containers = []
+    const _initContainers = []
+    mergedContainers.forEach(item => {
+      if (item.type === 'worker') {
+        delete item.type
+        _containers.push(item)
+      } else {
+        delete item.type
+        _initContainers.push(item)
+      }
+    })
+    set(this.fedFormTemplate, `${this.prefix}spec.containers`, _containers)
+    set(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      _initContainers
+    )
   }
 
   checkMaxUnavalable = volumes => {
@@ -329,10 +353,19 @@ class VolumeSettings extends React.Component {
       this.fedFormTemplate,
       `${this.prefix}spec.containers`,
       []
-    )
+    ).map(c => ({ ...c, type: 'work' }))
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    ).map(c => ({ ...c, type: 'init' }))
+
+    const mergedContainers = concat(containers, initContainers)
 
     newVolumeMounts.forEach(({ containerName, ...rest }) => {
-      const container = containers.find(item => item.name === containerName)
+      const container = mergedContainers.find(
+        item => item.name === containerName
+      )
 
       if (container) {
         container.volumeMounts = container.volumeMounts || []
@@ -359,8 +392,23 @@ class VolumeSettings extends React.Component {
           }))
       }
     })
-
-    set(this.fedFormTemplate, `${this.prefix}spec.containers`, containers)
+    const _containers = []
+    const _initContainers = []
+    mergedContainers.forEach(item => {
+      if (item.type === 'worker') {
+        delete item.type
+        _containers.push(item)
+      } else {
+        delete item.type
+        _initContainers.push(item)
+      }
+    })
+    set(this.fedFormTemplate, `${this.prefix}spec.containers`, _containers)
+    set(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      _initContainers
+    )
   }
 
   handleVolume(newVolume = {}, newVolumeMounts = []) {
@@ -413,6 +461,13 @@ class VolumeSettings extends React.Component {
       `${this.prefix}spec.containers`,
       []
     )
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    )
+
+    const mergedContainers = concat(containers, initContainers)
 
     return (
       <AddVolume
@@ -420,7 +475,7 @@ class VolumeSettings extends React.Component {
         volume={this.selectVolume}
         namespace={this.namespace}
         module={this.props.module}
-        containers={containers}
+        containers={mergedContainers}
         onSave={this.handleVolume}
         onCancel={this.resetState}
         isLoading={isLoading}
@@ -437,14 +492,21 @@ class VolumeSettings extends React.Component {
       `${this.prefix}spec.containers`,
       []
     )
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    )
+
+    const mergedContainers = concat(containers, initContainers)
 
     return (
       <MountConfig
         volume={this.selectVolume}
-        containers={containers}
+        containers={mergedContainers}
         cluster={this.cluster}
         namespace={this.namespace}
-        containers={containers}
+        containers={mergedContainers}
         onSave={this.handleVolume}
         onCancel={this.resetState}
         isFederated={isFederated}
@@ -462,12 +524,19 @@ class VolumeSettings extends React.Component {
       `${this.prefix}spec.containers`,
       []
     )
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    )
+
+    const mergedContainers = concat(containers, initContainers)
     const namespace = get(this.formTemplate, 'metadata.namespace', '')
 
     return (
       <AddVolumeTemplate
         volume={this.selectVolume}
-        containers={containers}
+        containers={mergedContainers}
         cluster={cluster}
         namespace={namespace}
         onSave={this.handleVolumeTemplate}
@@ -558,7 +627,13 @@ class VolumeSettings extends React.Component {
       `${this.prefix}spec.containers`,
       []
     )
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    )
 
+    const mergedContainers = concat(containers, initContainers)
     const showTip =
       get(this.fedFormTemplate, `${this.prefix}spec.volumes`, []).length ===
         0 &&
@@ -592,7 +667,7 @@ class VolumeSettings extends React.Component {
               <VolumeTemplateList
                 prefix={this.prefix}
                 name="spec.volumeClaimTemplates"
-                containers={containers}
+                containers={mergedContainers}
                 onShowAddVolume={this.showVolumeTemplate}
                 onShowEdit={this.showEditVolumeTemplate}
                 collectSavedLog={collectSavedLog}
@@ -605,7 +680,7 @@ class VolumeSettings extends React.Component {
               prefix={this.prefix}
               name={`${this.prefix}spec.volumes`}
               volumes={volumes}
-              containers={containers}
+              containers={mergedContainers}
               loading={isLoading}
               onShowVolume={this.showVolume}
               onShowConfig={this.showConfig}


### PR DESCRIPTION
Signed-off-by: Daniel Doni <sigboom@163.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4142

### Special notes for reviewers:
```
This is not the best solution，but it's the Simplest solution.
If you want to support more special styles, you should add a base interface for "initContainers", but it seems unnecessary now.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Update UI to support creating init container and mounting the volume.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
