### PR TITLE
feat: change the select component to the autoComplete component in ru…

### DIFF
--- a/src/components/Inputs/RulePath/index.jsx
+++ b/src/components/Inputs/RulePath/index.jsx
@@ -82,20 +82,16 @@ export default class RulePath extends React.Component {
   }
 
   render() {
-    const keyProps = {
-      component: AutoComplete,
-      options: this.services.map(item => item.value),
-    }
-    const { component: KeySelect, ...keyInputProps } = keyProps
+    const options = this.services.map(item => item.value)
     return (
       <ObjectInput {...this.props} onChange={this.handleChange}>
         <Input name="path" placeholder={t('Path')} defaultValue="/" />
-        <KeySelect
+        <AutoComplete
           className={styles.autocomplete}
           name="backend.serviceName"
           placeholder={t('PATH_SERVICE_TIP')}
           onChange={this.handleServiceChange}
-          {...keyInputProps}
+          options={options}
         />
         <Select
           className={styles.input}

--- a/src/components/Inputs/RulePath/index.jsx
+++ b/src/components/Inputs/RulePath/index.jsx
@@ -18,7 +18,7 @@
 
 import { get, set, isNumber } from 'lodash'
 import React from 'react'
-import { Input, Select } from '@kube-design/components'
+import { Input, Select, AutoComplete } from '@kube-design/components'
 import { ObjectInput } from 'components/Inputs'
 
 import styles from './index.scss'
@@ -82,15 +82,20 @@ export default class RulePath extends React.Component {
   }
 
   render() {
+    const keyProps = {
+      component: AutoComplete,
+      options: this.services.map(item => item.value),
+    }
+    const { component: KeySelect, ...keyInputProps } = keyProps
     return (
       <ObjectInput {...this.props} onChange={this.handleChange}>
         <Input name="path" placeholder={t('Path')} defaultValue="/" />
-        <Select
-          className="margin-r12"
+        <KeySelect
+          className={styles.autocomplete}
           name="backend.serviceName"
           placeholder={t('PATH_SERVICE_TIP')}
-          options={this.services}
           onChange={this.handleServiceChange}
+          {...keyInputProps}
         />
         <Select
           className={styles.input}

--- a/src/components/Inputs/RulePath/index.scss
+++ b/src/components/Inputs/RulePath/index.scss
@@ -7,3 +7,7 @@
     }
   }
 }
+
+.autocomplete {
+  width: 100% !important;
+}


### PR DESCRIPTION
…le config page.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:
this PR has changed the select component to the autoComplete component in the rule config page.
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes ##https://github.com/kubesphere/kubesphere/issues/4117

### Special notes for reviewers:
The final effect is as follows:
![image](https://user-images.githubusercontent.com/14542348/131060040-1f7686dd-02bb-4c08-ad0d-b88274343ae9.png)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support service name auto-complete when creating Route rule.
```
### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
