### PR TITLE
feat: Change the judgment field in storage management

### DIFF
--- a/locales/en/scheduleDeployment.js
+++ b/locales/en/scheduleDeployment.js
@@ -28,4 +28,12 @@ module.exports = {
   TOTAL_REPLICAS: 'Total Replicas',
   'replicas input invalid': 'Replicas input invalid.',
   'Please input total replicas num': 'Please input total replicas num.',
+  'Storage Function Manage': 'Storage volume function management',
+  'Volume Clone': 'Storage volume clone',
+  Volume_Clone_Des: 'Create an identical storage volume.',
+  Volume_SnapShot_Des:
+    'Create a storage volume snapshot, which can be used to create other storage volumes.',
+  'Volume Expansion': 'Storage volume expansion',
+  Volume_Expansion_Des:
+    'Increase the capacity of the storage volume. The capacity of the storage volume cannot be reduced on the console because data may be lost.',
 }

--- a/locales/es/scheduleDeployment.js
+++ b/locales/es/scheduleDeployment.js
@@ -28,4 +28,13 @@ module.exports = {
   TOTAL_REPLICAS: 'Número total de copias',
   'replicas input invalid': 'La entrada de copia es ilegal',
   'Please input total replicas num': 'Ingrese el número total de copias',
+  'Storage Function Manage':
+    'Gestión de la función de volumen de almacenamiento',
+  'Volume Clone': 'Clon de volumen de almacenamiento',
+  Volume_Clone_Des: 'Crea un volumen de almacenamiento idéntico.',
+  Volume_SnapShot_Des:
+    'Cree una instantánea del volumen de almacenamiento, que se puede utilizar para crear otros volúmenes de almacenamiento.',
+  'Volume Expansion': 'Expansión del volumen de almacenamiento',
+  Volume_Expansion_Des:
+    'Aumente la capacidad del volumen de almacenamiento. La capacidad del volumen de almacenamiento no se puede reducir en la consola porque se pueden perder datos.',
 }

--- a/locales/tc/scheduleDeployment.js
+++ b/locales/tc/scheduleDeployment.js
@@ -27,4 +27,11 @@ module.exports = {
   TOTAL_REPLICAS: '副本總數',
   'replicas input invalid': '副本輸入不合法',
   'Please input total replicas num': '請輸入副本總數',
+  'Storage Function Manage': '存儲卷功能管理',
+  'Volume Clone': '存儲卷克隆',
+  Volume_Clone_Des: '創建一個相同的存儲卷',
+  Volume_SnapShot_Des: '創建一個存儲卷快照，可用於創建其他存儲卷',
+  'Volume Expansion': '存儲卷擴容',
+  Volume_Expansion_Des:
+    '增加存儲卷的容量。無法在控制台上減少存儲卷的容量，因為數據可能會因此丟失。',
 }

--- a/locales/zh/scheduleDeployment.js
+++ b/locales/zh/scheduleDeployment.js
@@ -26,4 +26,11 @@ module.exports = {
   TOTAL_REPLICAS: '总副本数',
   'Please input total replicas num': '请输入副本总数',
   'replicas input invalid': '请输入正确的副本数',
+  'Storage Function Manage': '存储卷功能管理',
+  'Volume Clone': '存储卷克隆',
+  Volume_Clone_Des: '创建一个相同的存储卷。',
+  Volume_SnapShot_Des: '创建一个存储卷快照，可用于创建其他存储卷。',
+  'Volume Expansion': '存储卷扩容',
+  Volume_Expansion_Des:
+    '增加存储卷的容量。无法在控制台上减少存储卷的容量，因为数据可能会因此丢失。',
 }

--- a/src/actions/storageclass.js
+++ b/src/actions/storageclass.js
@@ -22,6 +22,7 @@ import { Modal } from 'components/Base'
 
 import CreateModal from 'components/Modals/Create'
 import SetDefaultStorageClassModal from 'components/Modals/SetDefaultStorageClass'
+import VolumeFunctionManage from 'components/Modals/VolumeFunctionManage'
 import { MODULE_KIND_MAP } from 'utils/constants'
 import FORM_TEMPLATES from 'utils/form.templates'
 import formPersist from 'utils/form.persist'
@@ -94,6 +95,33 @@ export default {
         cluster,
         modal: SetDefaultStorageClassModal,
         store,
+        ...props,
+      })
+    },
+  },
+  'storageclass.volume.function.update': {
+    on({ cluster, store, detail, StorageClassStore, success, ...props }) {
+      const modal = Modal.open({
+        onOk: async state => {
+          await store.patch(detail, {
+            annotations: {
+              'storageclass.kubesphere.io/allow-clone': state.allowClone,
+              'storageclass.kubesphere.io/allow-snapshot': state.allowSnapshot,
+            },
+            allowVolumeExpansion: state.allowVolumeExpansion,
+          })
+          await store.fetchDetail({
+            name: detail.name,
+            cluster: detail.cluster,
+          })
+          Notify.success({ content: `${t('Update Successfully')}` })
+          Modal.close(modal)
+          success && success()
+        },
+        cluster,
+        store,
+        modal: VolumeFunctionManage,
+        StorageClassStore,
         ...props,
       })
     },

--- a/src/components/Modals/VolumeFunctionManage/index.jsx
+++ b/src/components/Modals/VolumeFunctionManage/index.jsx
@@ -1,0 +1,129 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Toggle } from '@kube-design/components'
+import { Modal } from 'components/Base'
+
+import { get } from 'lodash'
+import { observer } from 'mobx-react'
+import styles from './index.scss'
+
+@observer
+export default class SetDefaultStorageClassModal extends React.Component {
+  static propTypes = {
+    visible: PropTypes.bool,
+    onOk: PropTypes.func,
+    onCancel: PropTypes.func,
+    isSubmitting: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    visible: false,
+    isSubmitting: false,
+    onOk() {},
+    onCancel() {},
+  }
+
+  state = this.getState
+
+  get getState() {
+    const { StorageClassStore: store } = this.props
+    const detail = store.detail
+    return {
+      allowClone: get(
+        detail.annotations,
+        'storageclass.kubesphere.io/allow-clone',
+        false
+      ),
+      allowSnapshot: get(
+        detail.annotations,
+        'storageclass.kubesphere.io/allow-snapshot',
+        false
+      ),
+      allowVolumeExpansion: get(detail, 'allowVolumeExpansion', false),
+    }
+  }
+
+  get Items() {
+    return [
+      {
+        title: t('Volume Clone'),
+        des: t('Volume_Clone_Des'),
+        key: 'allowClone',
+        onclick: checked =>
+          this.setState({
+            allowClone: !checked,
+          }),
+      },
+      {
+        title: t('Volume Snapshot'),
+        des: t('Volume_SnapShot_Des'),
+        key: 'allowSnapshot',
+        onclick: checked => this.setState({ allowSnapshot: !checked }),
+      },
+      {
+        title: t('Volume Expansion'),
+        des: t('Volume_Expansion_Des'),
+        key: 'allowVolumeExpansion',
+        onclick: checked =>
+          this.setState({
+            allowVolumeExpansion: !checked,
+          }),
+      },
+    ]
+  }
+
+  render() {
+    const { visible, onCancel, onOk, isSubmitting } = this.props
+    return (
+      <Modal
+        width={600}
+        onOk={() => onOk(this.state)}
+        onCancel={onCancel}
+        visible={visible}
+        title={t('Storage Function Manage')}
+        icon="slider"
+        okText={t('Confirm')}
+        cancelText={t('Cancel')}
+        isSubmitting={isSubmitting}
+      >
+        <div className={styles.body}>
+          {this.Items.map(item => {
+            const checked = this.state[item.key]
+            return (
+              <div className={styles.Item} key={item.title}>
+                <div className={styles.icon}>
+                  <Toggle
+                    checked={checked}
+                    onChange={() => item.onclick(checked)}
+                  ></Toggle>
+                </div>
+                <div className={styles.textBox}>
+                  <span className={styles.title}>{item.title}</span>
+                  <span className={styles.des}>{item.des}</span>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </Modal>
+    )
+  }
+}

--- a/src/components/Modals/VolumeFunctionManage/index.scss
+++ b/src/components/Modals/VolumeFunctionManage/index.scss
@@ -1,0 +1,58 @@
+@import '~scss/variables';
+
+.body {
+  .Item {
+    display: flex;
+    box-sizing: border-box;
+    width: 560px;
+    min-height: 64px;
+    border: 1px solid $light-color06;
+    box-sizing: border-box;
+    border-radius: 4px;
+    padding: 12px;
+
+    &:nth-of-type(2) {
+      margin: 12px 0;
+    }
+
+    .icon {
+      margin-right: 8px;
+
+      label {
+        min-width: 32px;
+        height: 16px;
+        border-radius: 8px;
+      }
+
+      :global {
+        .toggle:after {
+          left: 2px;
+        }
+
+        .toggle.checked:after {
+          left: 100%;
+          transform: translateX(calc(-100% - 2px)) translateY(-50%);
+        }
+      }
+    }
+
+    .textBox {
+      span {
+        display: block;
+      }
+
+      .title {
+        font-weight: 600;
+        font-size: 12px;
+        color: $dark-color07;
+        line-height: 20px;
+      }
+
+      .des {
+        font-size: 12px;
+        line-height: 20px;
+        color: $dark-color01;
+      }
+    }
+  }
+}

--- a/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
+++ b/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
@@ -69,14 +69,14 @@ export default class StorageClassDetail extends React.Component {
 
   getOperations = () => [
     {
-      key: 'viewYaml',
+      key: 'editYaml',
       type: 'default',
-      text: t('View YAML'),
-      action: 'view',
+      text: t('EDIT_YAML'),
+      action: 'edit',
       onClick: () =>
         this.trigger('resource.yaml.edit', {
           detail: toJS(this.store.detail),
-          readOnly: true,
+          readOnly: false,
         }),
     },
     {
@@ -88,6 +88,18 @@ export default class StorageClassDetail extends React.Component {
         this.trigger('storageclass.set.default', {
           detail: toJS(this.store.detail),
           defaultStorageClass: this.defaultStorageClass.name,
+          success: this.fetchData,
+        }),
+    },
+    {
+      key: 'funcManage',
+      icon: 'slider',
+      text: t('Storage Function Manage'),
+      action: 'edit',
+      onClick: () =>
+        this.trigger('storageclass.volume.function.update', {
+          detail: toJS(this.store.detail),
+          StorageClassStore: this.store,
           success: this.fetchData,
         }),
     },

--- a/src/pages/projects/containers/Volumes/Detail/index.jsx
+++ b/src/pages/projects/containers/Volumes/Detail/index.jsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react'
-import { isEmpty, get } from 'lodash'
+import { isEmpty, get, isUndefined } from 'lodash'
 import { observer, inject } from 'mobx-react'
 import { Loading } from '@kube-design/components'
 
@@ -27,7 +27,6 @@ import { trigger } from 'utils/action'
 import { toJS } from 'mobx'
 import Volume from 'stores/volume'
 import StorageClass from 'stores/storageClass'
-import StorageClassCapability from 'stores/storageclasscapabilities'
 
 import DetailPage from 'projects/containers/Base/Detail'
 
@@ -40,8 +39,6 @@ export default class VolumeDetail extends React.Component {
   store = new Volume()
 
   storageclass = new StorageClass()
-
-  storageclasscapabilities = new StorageClassCapability()
 
   componentDidMount() {
     this.fetchData()
@@ -77,17 +74,34 @@ export default class VolumeDetail extends React.Component {
     return this.store.detail.isFedManaged
   }
 
+  get allowClone() {
+    try {
+      const clone = toJS(this.storageclass).detail.annotations[
+        'storageclass.kubesphere.io/allow-clone'
+      ]
+      return isUndefined(clone) ? true : clone
+    } catch (err) {
+      return true
+    }
+  }
+
+  get allowSnapshot() {
+    try {
+      const snapShot = toJS(this.storageclass).detail.annotations[
+        'storageclass.kubesphere.io/allow-snapshot'
+      ]
+      return isUndefined(snapShot) ? true : snapShot
+    } catch (err) {
+      return true
+    }
+  }
+
   fetchData = async () => {
     const { cluster } = this.props.match.params
     await this.store.fetchDetail(this.props.match.params)
 
     const { storageClassName } = this.store.detail
     await this.storageclass.fetchDetail({
-      cluster,
-      name: storageClassName,
-    })
-
-    await this.storageclasscapabilities.fetchDetail({
       cluster,
       name: storageClassName,
     })
@@ -123,11 +137,7 @@ export default class VolumeDetail extends React.Component {
       text: t('Clone Volume'),
       icon: 'copy',
       action: 'create',
-      disabled: !get(
-        this.storageclasscapabilities,
-        'detail.volumeFeature.clone',
-        false
-      ),
+      disabled: this.allowClone,
       onClick: () => {
         this.trigger('volume.clone', {})
       },
@@ -138,11 +148,7 @@ export default class VolumeDetail extends React.Component {
       text: t('Create Snapshot'),
       icon: 'copy',
       action: 'create',
-      disabled: !get(
-        this.storageclasscapabilities,
-        'detail.snapshotFeature.create',
-        false
-      ),
+      disabled: this.allowSnapshot,
       onClick: () => {
         this.trigger('volume.create.snapshot', {})
       },
@@ -152,11 +158,7 @@ export default class VolumeDetail extends React.Component {
       text: t('Expand Volume'),
       icon: 'scaling',
       action: 'edit',
-      disabled: !get(
-        this.storageclasscapabilities,
-        'detail.supportExpandVolume',
-        false
-      ),
+      disabled: !get(this.storageclass.detail, 'allowVolumeExpansion', false),
       onClick: () => {
         const { detail, isSubmitting } = this.store
         const originData = toJS(detail._originData)


### PR DESCRIPTION
### What type of PR is this?
/kind feature

### What this PR does / why we need it:
- use the judgment field as follows:
    - annotations['storageclass.kubesphere.io/allow-clone'] :  'true'
    - annotations['storageclass.kubesphere.io/allow-snapshot'] :  'true'
    - allowVolumeExpansion: true

### Which issue(s) this PR fixes:
Fixes ##2158

### Special notes for reviewers:
```
```
https://user-images.githubusercontent.com/33231138/131305218-c53ff323-cea4-4b1b-9fe0-9bf067385d33.mov

### Does this PR introduced a user-facing change?
```release-note
Change the judgment field in storage management 
```

### Additional documentation, usage docs, etc.:
```docs

```
