### PR TITLE
fix: Fix the pod render in workload of alerting

### DIFF
--- a/src/pages/projects/containers/Alerting/Messages/index.jsx
+++ b/src/pages/projects/containers/Alerting/Messages/index.jsx
@@ -149,7 +149,10 @@ export default class AlertingPolicy extends React.Component {
           <Text
             icon="loudspeaker"
             title={get(record, 'annotations.summary')}
-            description={get(record, 'annotations.message', '-')}
+            description={
+              get(record, 'annotations.message') ||
+              get(record, 'annotations.description', '-')
+            }
           />
         ),
       },
@@ -214,6 +217,13 @@ export default class AlertingPolicy extends React.Component {
             return '-'
           }
 
+          if (module === 'hpas') {
+            return (
+              <span>
+                {t(MODULE_KIND_MAP[module])}: {name}
+              </span>
+            )
+          }
           return (
             <Link to={`${this.getPrefix({ namespace })}/${module}/${name}`}>
               {t(MODULE_KIND_MAP[module])}: {name}

--- a/src/pages/projects/containers/Alerting/Policies/Detail/AlertMessages/index.jsx
+++ b/src/pages/projects/containers/Alerting/Policies/Detail/AlertMessages/index.jsx
@@ -89,7 +89,10 @@ export default class AlertHistory extends React.Component {
         <Text
           icon="loudspeaker"
           title={get(record, 'annotations.summary')}
-          description={get(record, 'annotations.message', '-')}
+          description={
+            get(record, 'annotations.message') ||
+            get(record, 'annotations.description', '-')
+          }
         />
       ),
     },
@@ -116,6 +119,13 @@ export default class AlertHistory extends React.Component {
           return '-'
         }
 
+        if (module === 'hpas') {
+          return (
+            <span>
+              {t(MODULE_KIND_MAP[module])}: {name}
+            </span>
+          )
+        }
         return (
           <Link to={`${this.getPrefix({ namespace })}/${module}/${name}`}>
             {t(MODULE_KIND_MAP[module])}: {name}

--- a/src/utils/alerting.js
+++ b/src/utils/alerting.js
@@ -78,6 +78,14 @@ export const getAlertingResource = (labels = {}) => {
         namespace: _labels.namespace,
       }
     }
+
+    const module = workloadType === 'job_name' ? 'jobs' : `${workloadType}s`
+
+    return {
+      module,
+      name: _labels[workloadType],
+      namespace: _labels.namespace,
+    }
   }
 
   if (labels.node) {
@@ -97,21 +105,11 @@ export const getAlertingResource = (labels = {}) => {
     }
 
     if (labels.job_name) {
-      renderPod(labels, 'job_name')
-      return {
-        module: 'jobs',
-        name: labels.job_name,
-        namespace: labels.namespace,
-      }
+      return renderPod(labels, 'job_name')
     }
 
     if (labels.cronjob) {
-      renderPod(labels, 'cronjob')
-      return {
-        module: 'cronjobs',
-        name: labels.cronjob,
-        namespace: labels.namespace,
-      }
+      return renderPod(labels, 'cronjob')
     }
 
     if (labels.hpa) {
@@ -123,30 +121,15 @@ export const getAlertingResource = (labels = {}) => {
     }
 
     if (labels.deployment) {
-      renderPod(labels, 'deployment')
-      return {
-        module: 'deployments',
-        name: labels.deployment,
-        namespace: labels.namespace,
-      }
+      return renderPod(labels, 'deployment')
     }
 
     if (labels.statefulset) {
-      renderPod(labels, 'statefulsets')
-      return {
-        module: 'statefulsets',
-        name: labels.statefulset,
-        namespace: labels.namespace,
-      }
+      return renderPod(labels, 'statefulset')
     }
 
     if (labels.daemonset) {
-      renderPod(labels, 'daemonsets')
-      return {
-        module: 'daemonsets',
-        name: labels.daemonset,
-        namespace: labels.namespace,
-      }
+      return renderPod(labels, 'daemonset')
     }
 
     if (labels.pod) {

--- a/src/utils/alerting.js
+++ b/src/utils/alerting.js
@@ -68,6 +68,18 @@ const KIND_MODULE = {
 }
 
 export const getAlertingResource = (labels = {}) => {
+  const renderPod = (_labels, workloadType) => {
+    const podsName = _labels.pod
+
+    if (podsName && podsName.startsWith(_labels[workloadType])) {
+      return {
+        module: 'pods',
+        name: _labels.pod,
+        namespace: _labels.namespace,
+      }
+    }
+  }
+
   if (labels.node) {
     return {
       module: 'nodes',
@@ -84,15 +96,34 @@ export const getAlertingResource = (labels = {}) => {
       }
     }
 
-    if (labels.pod) {
+    if (labels.job_name) {
+      renderPod(labels, 'job_name')
       return {
-        module: 'pods',
-        name: labels.pod,
+        module: 'jobs',
+        name: labels.job_name,
+        namespace: labels.namespace,
+      }
+    }
+
+    if (labels.cronjob) {
+      renderPod(labels, 'cronjob')
+      return {
+        module: 'cronjobs',
+        name: labels.cronjob,
+        namespace: labels.namespace,
+      }
+    }
+
+    if (labels.hpa) {
+      return {
+        module: 'hpas',
+        name: labels.hpa,
         namespace: labels.namespace,
       }
     }
 
     if (labels.deployment) {
+      renderPod(labels, 'deployment')
       return {
         module: 'deployments',
         name: labels.deployment,
@@ -101,6 +132,7 @@ export const getAlertingResource = (labels = {}) => {
     }
 
     if (labels.statefulset) {
+      renderPod(labels, 'statefulsets')
       return {
         module: 'statefulsets',
         name: labels.statefulset,
@@ -109,9 +141,18 @@ export const getAlertingResource = (labels = {}) => {
     }
 
     if (labels.daemonset) {
+      renderPod(labels, 'daemonsets')
       return {
         module: 'daemonsets',
         name: labels.daemonset,
+        namespace: labels.namespace,
+      }
+    }
+
+    if (labels.pod) {
+      return {
+        module: 'pods',
+        name: labels.pod,
         namespace: labels.namespace,
       }
     }

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -266,6 +266,7 @@ export const MODULE_KIND_MAP = {
   ippools: 'IPPool',
   groups: 'Group',
   volumes: 'Volumes',
+  hpas: 'Hpas',
 }
 
 export const QUOTAS_MAP = {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -266,7 +266,7 @@ export const MODULE_KIND_MAP = {
   ippools: 'IPPool',
   groups: 'Group',
   volumes: 'Volumes',
-  hpas: 'Hpas',
+  hpas: 'HPA',
 }
 
 export const QUOTAS_MAP = {


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu_5@163.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:

/kind bug



### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fix the pod render in workload of alerting
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
