### PR TITLE
Specifies the latest image's tag as the branch name

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Build image
       if: github.event_name == 'push'
-      run: docker build  --pull --file Dockerfile --tag $IMAGE_NAME  . 
+      run: docker build  --pull --file Dockerfile --tag $IMAGE_NAME  .
 
     - name: Docker login
       if: github.event_name == 'push'
@@ -60,10 +60,10 @@ jobs:
       run: |
           IMAGE_ID=$DOCKERHUB_REPO/$IMAGE_NAME
           # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          VERSION=${GITHUB_REF#refs/*/}
           # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-          [ "$VERSION" == "dev" ] && VERSION=dev
+          # [ "$VERSION" == "master" ] && VERSION=latest
+          # [ "$VERSION" == "dev" ] && VERSION=dev
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION


### PR DESCRIPTION
Signed-off-by: feng <guofeng@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup



### What this PR does / why we need it:
The latest image's tag is named as the branch name to ensure that the latest image's tag is consistent with the branch name.

### Does this PR introduced a user-facing change?
```release-note
NONE
```