### PR TITLE
fix: Remove node status icon

### DIFF
--- a/src/pages/clusters/containers/Monitor/Cluster/Overview/index.jsx
+++ b/src/pages/clusters/containers/Monitor/Cluster/Overview/index.jsx
@@ -224,10 +224,6 @@ class Overview extends React.Component {
         type: 'scheduler',
         name: t('KUBERNETES_SCHEDULER'),
       },
-      {
-        type: 'node',
-        name: t('NODE'),
-      },
     ]
 
     return (


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <1512298456@qq.com>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
hide the cluster status icon.

### Which issue(s) this PR fixes:
Fixes ##2201

### Special notes for reviewers:
![截屏2021-09-08 16 09 32](https://user-images.githubusercontent.com/33231138/132471673-dacaf1e5-8806-4ff5-8637-90cf3313fd5b.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
