### PR TITLE
support client authentication

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -1,5 +1,4 @@
 # kubesphere configuration
-
 server:
   http:
     hostname: localhost
@@ -27,6 +26,8 @@ server:
 
   # backend service gateway server
   apiServer:
+    clientID: kubesphere
+    clientSecret: kubesphere
     url: http://ks-apiserver.kubesphere-system.svc
     wsUrl: ws://ks-apiserver.kubesphere-system.svc
 

--- a/server/controllers/session.js
+++ b/server/controllers/session.js
@@ -66,6 +66,7 @@ const handleLogin = async ctx => {
       ctx.app.emit('error', err)
 
       switch (err.code) {
+        case 400:
         case 401:
           Object.assign(error, {
             status: err.code,

--- a/server/services/session.js
+++ b/server/services/session.js
@@ -24,7 +24,9 @@ const jwtDecode = require('jwt-decode')
 
 const { send_gateway_request } = require('../libs/request')
 
-const { isAppsRoute, safeParseJSON } = require('../libs/utils')
+const { isAppsRoute, safeParseJSON, getServerConfig } = require('../libs/utils')
+
+const { server: serverConfig } = getServerConfig()
 
 const handleLoginResp = (resp = {}) => {
   if (!resp.access_token) {
@@ -51,6 +53,19 @@ const handleLoginResp = (resp = {}) => {
 }
 
 const login = async (data, headers) => {
+  let clientID = serverConfig.apiServer.clientID
+  if (!clientID) {
+    clientID = 'kubesphere'
+  }
+
+  let clientSecret = serverConfig.apiServer.clientSecret
+  if (!clientSecret) {
+    clientSecret = 'kubesphere'
+  }
+
+  data.client_id = clientID
+  data.client_secret = clientSecret
+
   const resp = await send_gateway_request({
     method: 'POST',
     url: '/oauth/token',
@@ -71,16 +86,31 @@ const getNewToken = async ctx => {
   const refreshToken = ctx.cookies.get('refreshToken')
   let newToken = {}
 
+  const data = {
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+  }
+
+  let clientID = serverConfig.apiServer.clientID
+  if (!clientID) {
+    clientID = 'kubesphere'
+  }
+
+  let clientSecret = serverConfig.apiServer.clientSecret
+  if (!clientSecret) {
+    clientSecret = 'kubesphere'
+  }
+
+  data.client_id = clientID
+  data.client_secret = clientSecret
+
   const resp = await send_gateway_request({
     method: 'POST',
     url: '/oauth/token',
     headers: {
       'content-type': 'application/x-www-form-urlencoded',
     },
-    params: {
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-    },
+    params: data,
     token: refreshToken,
   })
 


### PR DESCRIPTION
Signed-off-by: hongming <hongming@kubesphere.io>



### What type of PR is this?

/kind api-change

### What this PR does / why we need it:

For security reasons, client authentication for confidential clients is required when posting an access token request. `client_secret` and `client_id` are configurable.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2256

### Does this PR introduced a user-facing change?

```release-note
None
```
