### PR TITLE
fix: Check the backend if support pv manag

### DIFF
--- a/src/pages/clusters/containers/Storage/PV/index.jsx
+++ b/src/pages/clusters/containers/Storage/PV/index.jsx
@@ -140,11 +140,22 @@ export default class PV extends React.Component {
         ),
       },
       {
-        title: t('ACCESS_MODE_TCAP'),
+        title: t('CAPACITY'),
         dataIndex: 'capacity',
         isHideable: true,
+        width: '7%',
+        render: (_, { capacity }) => (
+          <div>
+            <p>{capacity}</p>
+          </div>
+        ),
+      },
+      {
+        title: t('ACCESS_MODE_TCAP'),
+        dataIndex: 'accessMode',
+        isHideable: true,
         width: '12.32%',
-        render: (capacity, { accessMode }) => (
+        render: (_, { accessMode }) => (
           <div>
             <p>{accessMode}</p>
           </div>
@@ -156,6 +167,17 @@ export default class PV extends React.Component {
         isHideable: true,
         width: '7.74%',
         render: _ => _.spec.persistentVolumeReclaimPolicy,
+      },
+      {
+        title: t('volumeHandle'),
+        dataIndex: 'volumeHandle',
+        isHideable: true,
+        width: '9.8%',
+        render: (_, { volumeHandle }) => (
+          <div>
+            <p>{volumeHandle}</p>
+          </div>
+        ),
       },
       {
         title: t('CREATED_AT'),

--- a/src/pages/clusters/containers/Storage/Volumes/Volume/index.jsx
+++ b/src/pages/clusters/containers/Storage/Volumes/Volume/index.jsx
@@ -144,7 +144,20 @@ export default class Volumes extends React.Component {
     const { getSortOrder, getFilteredValue } = this.props
     const { cluster } = this.props.match.params
 
-    return [
+    const pvColumn = {
+      title: t('VOLUME_BACKEND_TCAP'),
+      dataIndex: '_originData',
+      isHideable: true,
+      search: false,
+      width: '28.5%',
+      render: _ => (
+        <Link to={`/clusters/${cluster}/pv/${_.spec.volumeName}`}>
+          {_.spec.volumeName}
+        </Link>
+      ),
+    }
+
+    const allColumns = [
       {
         title: t('NAME'),
         dataIndex: 'name',
@@ -169,25 +182,13 @@ export default class Volumes extends React.Component {
         search: true,
         filters: this.getStatus(),
         filteredValue: getFilteredValue('status'),
-        width: '10.56%',
+        width: '8.8%',
         render: (_, { phase }) => (
           <Status
             type={phase}
             name={t(`VOLUME_STATUS_${phase.toUpperCase()}`)}
             flicker
           />
-        ),
-      },
-      {
-        title: t('VOLUME_BACKEND_TCAP'),
-        dataIndex: '_originData',
-        isHideable: true,
-        search: false,
-        width: '28.5%',
-        render: _ => (
-          <Link to={`/clusters/${cluster}/pv/${_.spec.volumeName}`}>
-            {_.spec.volumeName}
-          </Link>
         ),
       },
       {
@@ -218,6 +219,12 @@ export default class Volumes extends React.Component {
         render: time => getLocalTime(time).format('YYYY-MM-DD HH:mm'),
       },
     ]
+
+    if (this.props.store.supportPv) {
+      allColumns.splice(2, 0, pvColumn)
+    }
+
+    return allColumns
   }
 
   showCreate = () => {

--- a/src/pages/clusters/containers/Storage/Volumes/index.jsx
+++ b/src/pages/clusters/containers/Storage/Volumes/index.jsx
@@ -21,11 +21,17 @@ import React from 'react'
 import { observer, inject } from 'mobx-react'
 import Banner from 'components/Cards/Banner'
 import { renderRoutes } from 'utils/router.config'
+import PVStore from 'stores/pv'
 import routes from './routes'
 
 @inject('rootStore')
 @observer
 export default class Volumes extends React.Component {
+  constructor(props) {
+    super(props)
+    this.pv = new PVStore()
+  }
+
   get tips() {
     return [
       {
@@ -57,10 +63,19 @@ export default class Volumes extends React.Component {
       }))
   }
 
+  renderBanner() {
+    if (this.pv.supportPv) {
+      return (
+        <Banner {...this.bannerProps} tips={this.tips} routes={this.routes} />
+      )
+    }
+    return <Banner {...this.bannerProps} tips={this.tips} />
+  }
+
   render() {
     return (
       <>
-        <Banner {...this.bannerProps} tips={this.tips} routes={this.routes} />
+        {this.renderBanner()}
         {renderRoutes(routes)}
       </>
     )

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -48,6 +48,17 @@ export default class BaseStore {
     return ObjectMapper[this.module] || (data => data)
   }
 
+  get supportPv() {
+    const ksVersion = globals.ksConfig.ksVersion.replace(/[^\d.]/g, '')
+    const version = Number(
+      ksVersion
+        .split('.')
+        .slice(0, 2)
+        .join('.')
+    )
+    return version >= 3.2
+  }
+
   getPath({ cluster, namespace } = {}) {
     let path = ''
     if (cluster) {

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -511,9 +511,10 @@ const PVMapper = item => {
     storageClassName: get(item, 'spec.storageClassName'),
     capacity: get(
       item,
-      'status.capacity.storage',
+      'spec.capacity.storage',
       get(item, 'spec.resources.requests.storage')
     ),
+    volumeHandle: get(item, 'spec.csi.volumeHandle'),
     inUse: get(item, 'metadata.annotations["kubesphere.io/in-use"]') === 'true',
     type: 'pvc',
     persistentVolumeReclaimPolicy: get(


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
if  the ksVersion Less than 3.2, the pv manage tab will not show.
![截屏2021-09-27 22 40 27](https://user-images.githubusercontent.com/33231138/134930714-64b87b96-ce56-4e2f-82da-6fa6a1647dd9.png)

![截屏2021-09-27 22 41 42](https://user-images.githubusercontent.com/33231138/134930933-2a5fdb85-6887-4c66-892c-b6a97353effd.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
