### PR TITLE
fix: Fix the default time range is displayed incorrectly on the overview page

### DIFF
--- a/src/pages/fedprojects/containers/Overview/ResourceUsage/index.jsx
+++ b/src/pages/fedprojects/containers/Overview/ResourceUsage/index.jsx
@@ -296,7 +296,7 @@ class ResourceUsage extends React.Component {
 
         <Select
           className={styles.timeSelect}
-          value={this.state.range}
+          defaultValue={this.state.range}
           options={this.timeOptions}
           onChange={this.handleRangeChange}
         />

--- a/src/pages/projects/containers/Overview/ResourceUsage/index.jsx
+++ b/src/pages/projects/containers/Overview/ResourceUsage/index.jsx
@@ -320,7 +320,7 @@ class ResourceUsage extends React.Component {
         </RadioGroup>
         <Select
           className={styles.timeSelect}
-          value={this.state.range}
+          defaultValue={this.state.range}
           options={this.timeOptions}
           onChange={this.handleRangeChange}
         />


### PR DESCRIPTION
…
Signed-off-by: lannyfu <lannyfu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2338

### Special notes for reviewers:
```
```

https://user-images.githubusercontent.com/63338728/135040635-abec5257-50b8-42f4-b135-c17258afe432.mov


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fix the default time range for displaying errors
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
