### PR TITLE
Avoid gh repo fork prompt

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -14,7 +14,9 @@ tasks:
 
       [[ ! -z "${DOCKER_USER}" && ! -z "${DOCKER_PASSWD}" ]] && docker login -u${DOCKER_USER} -p${DOCKER_PASSWD}
       [[ ! -z "${GITHUB_USER}" && ! -z "${GITHUB_TOKEN}" ]] && docker login ghcr.io -u${GITHUB_USER} -p${GITHUB_TOKEN}
-      gh repo fork --remote
+      echo kubesphere/console | gh repo fork --remote
+
+      make image image-push
 
       cp /home/gitpod/local_config.yaml /workspace/console/server/local_config.yaml
       gp open /workspace/console/server/local_config.yaml


### PR DESCRIPTION


<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup


### What this PR does / why we need it:

With the help of gitpod, users can build and push ks-console image to dockerhub easily. With these changes, users don't need to do anything except opening the gitpod adress.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:

```
? Which should be the base repository (used for e.g. querying issues) for this directory?  [Use arrows to move, type to filter]
> kubesphere/console
  harrisonliu5/console
```

With these changes, users don't need to type anything:
```
 HISTFILE=/workspace/.gitpod/cmd-0 history -r; {
git config --global user.name $GIT_AUTHOR_NAME
git config --global user.email $GIT_COMMITTER_EMAIL

[[ ! -z "${DOCKER_USER}" && ! -z "${DOCKER_PASSWD}" ]] && docker login -u${DOCKER_USER} -p${DOCKER_PASSWD}
[[ ! -z "${GITHUB_USER}" && ! -z "${GITHUB_TOKEN}" ]] && docker login ghcr.io -u${GITHUB_USER} -p${GITHUB_TOKEN}
echo kubesphere/console | gh repo fork --remote

make image image-push

cp /home/gitpod/local_config.yaml /workspace/console/server/local_config.yaml
gp open /workspace/console/server/local_config.yaml
sed 's/hostname.*:/hostname.replace("8000", "8001") :/' server/views/index.html -i
sed 's/hostname/hostname.replace("8000", "8001")/' server/components/boot.js -i
sed 's/http:/https:/' server/components/boot.js -i
sed 's/:8001//' server/components/boot.js -i
yarn

} && {
yarn start
}
gitpod /workspace/console $  HISTFILE=/workspace/.gitpod/cmd-0 history -r; {
> git config --global user.name $GIT_AUTHOR_NAME
> git config --global user.email $GIT_COMMITTER_EMAIL
> 
> [[ ! -z "${DOCKER_USER}" && ! -z "${DOCKER_PASSWD}" ]] && docker login -u${DOCKER_USER} -p${DOCKER_PASSWD}
> [[ ! -z "${GITHUB_USER}" && ! -z "${GITHUB_TOKEN}" ]] && docker login ghcr.io -u${GITHUB_USER} -p${GITHUB_TOKEN}
> echo kubesphere/console | gh repo fork --remote
> 
> make image image-push
> 
> cp /home/gitpod/local_config.yaml /workspace/console/server/local_config.yaml
> gp open /workspace/console/server/local_config.yaml
> sed 's/hostname.*:/hostname.replace("8000", "8001") :/' server/views/index.html -i
> sed 's/hostname/hostname.replace("8000", "8001")/' server/components/boot.js -i
> sed 's/http:/https:/' server/components/boot.js -i
> sed 's/:8001//' server/components/boot.js -i
> yarn
> 
> } && {
> yarn start
> }
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/gitpod/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/gitpod/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
LinuxSuRen/console already exists

A new release of gh is available: 1.10.2 → v2.0.0
https://github.com/cli/cli/releases/tag/v2.0.0

rm -rf build && mkdir -p build
tar --exclude=".git" --exclude='node_modules' --exclude='build' --warning=no-file-changed -czf build/console.tar.gz .
docker build build -t surenpi:avoid-gh-prompt-dev -f Dockerfile.multistage
Sending build context to Docker daemon  4.169MB
Step 1/14 : FROM node:12.18 as builder
12.18: Pulling from library/node
4f250268ed6a: Pull complete 
1b49aa113642: Pull complete 
c159512f4cc2: Pull complete 
8439168fd8dc: Pull complete 
55abbc6cc158: Pull complete 
e5c5821cd889: Pull complete 
fe68f8ffb64f: Pull complete 
310e01487093: Extracting [>                                                  ]  32.77kB/2.362MB
3d7627cf0abe: Download complete
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
