### PR TITLE
fix: Change pvc access modes to list 

### DIFF
--- a/src/components/Forms/Volume/VolumeSettings/AccessModeSelectForm/index.jsx
+++ b/src/components/Forms/Volume/VolumeSettings/AccessModeSelectForm/index.jsx
@@ -36,24 +36,11 @@ export default class VolumeSettings extends React.Component {
 
     return (
       <Form data={this.formTemplate} ref={formRef}>
-        {/* <Form.Item label={t('ACCESS_MODE_TCAP')} rules={[{ required: true }]}>
+        <Form.Item label={t('ACCESS_MODE_TCAP')} rules={[{ required: true }]}>
           <AccessModes
             name={ACCESSMODE_KEY}
             defaultValue={get(supportedAccessModes, '[0]', '')}
             supportedAccessModes={supportedAccessModes}
-          />
-        </Form.Item> */}
-
-        <Form.Item label={t('ACCESS_MODE')} desc={t('ACCESS_MODES_DESC')}>
-          <Select
-            name={'spec.accessModes'}
-            options={[
-              { label: 'ReadWriteOnce', value: 'ReadWriteOnce' },
-              { label: 'ReadOnlyMany', value: 'ReadOnlyMany' },
-              { label: 'ReadWriteMany', value: 'ReadWriteMany' },
-            ]}
-            defaultValue={['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany']}
-            multi
           />
         </Form.Item>
       </Form>

--- a/src/components/Forms/Volume/VolumeSettings/AccessModeSelectForm/index.jsx
+++ b/src/components/Forms/Volume/VolumeSettings/AccessModeSelectForm/index.jsx
@@ -36,11 +36,24 @@ export default class VolumeSettings extends React.Component {
 
     return (
       <Form data={this.formTemplate} ref={formRef}>
-        <Form.Item label={t('ACCESS_MODE_TCAP')} rules={[{ required: true }]}>
+        {/* <Form.Item label={t('ACCESS_MODE_TCAP')} rules={[{ required: true }]}>
           <AccessModes
             name={ACCESSMODE_KEY}
             defaultValue={get(supportedAccessModes, '[0]', '')}
             supportedAccessModes={supportedAccessModes}
+          />
+        </Form.Item> */}
+
+        <Form.Item label={t('ACCESS_MODE')} desc={t('ACCESS_MODES_DESC')}>
+          <Select
+            name={'spec.accessModes'}
+            options={[
+              { label: 'ReadWriteOnce', value: 'ReadWriteOnce' },
+              { label: 'ReadOnlyMany', value: 'ReadOnlyMany' },
+              { label: 'ReadWriteMany', value: 'ReadWriteMany' },
+            ]}
+            defaultValue={['ReadWriteOnce', 'ReadOnlyMany', 'ReadWriteMany']}
+            multi
           />
         </Form.Item>
       </Form>

--- a/src/components/Forms/Volume/VolumeSettings/FormTemplate.jsx
+++ b/src/components/Forms/Volume/VolumeSettings/FormTemplate.jsx
@@ -30,6 +30,7 @@ import StorageClassStore from 'stores/storageClass'
 
 const STORAGE_CLASSES_KEY = 'spec.storageClassName'
 const ACCESSMODE_KEY = 'spec.accessModes'
+const PREFERABLE_DEFAULT_ACCESS_MODE = 'ReadWriteOnce'
 
 export default class VolumeSettings extends React.Component {
   static contextTypes = {
@@ -169,14 +170,23 @@ export default class VolumeSettings extends React.Component {
     const storageClasses = this.getStorageClasses()
     const storageClassesList = this.store.list || {}
 
+    // If annotations cannot be found or the number of modes is 0:
+    // Think that all three modes are available
     const supportedAccessModes =
       this.getSupportedAccessModes() ?? Object.keys(ACCESS_MODES)
     const supportedAccessModesSelectOptions = supportedAccessModes.map(
       mode => ({
         value: mode,
-        label: `${mode}: ${t(`ACCESS_MODE_${ACCESS_MODES[mode]}`)}`,
+        label: mode,
       })
     )
+
+    // If there is "ReadWriteOnce", "ReadWriteOnce"is checked by default,
+    // otherwise, the first value in the list is checked by default.
+    const defaultAccessModes =
+      PREFERABLE_DEFAULT_ACCESS_MODE in supportedAccessModes
+        ? [PREFERABLE_DEFAULT_ACCESS_MODE]
+        : supportedAccessModes.slice(0, 1)
 
     return (
       <>
@@ -208,7 +218,7 @@ export default class VolumeSettings extends React.Component {
               name={ACCESSMODE_KEY}
               options={supportedAccessModesSelectOptions}
               loading={isLoading}
-              defaultValue={[]}
+              defaultValue={defaultAccessModes}
               multi
             />
           </Form.Item>

--- a/src/components/Forms/Volume/VolumeSettings/FormTemplate.jsx
+++ b/src/components/Forms/Volume/VolumeSettings/FormTemplate.jsx
@@ -24,12 +24,12 @@ import { PropTypes } from 'prop-types'
 import { safeParseJSON } from 'utils'
 import { ACCESS_MODES } from 'utils/constants'
 import { Form, Select } from '@kube-design/components'
-import { AccessModes, UnitSlider } from 'components/Inputs'
+import { UnitSlider } from 'components/Inputs'
 
 import StorageClassStore from 'stores/storageClass'
 
 const STORAGE_CLASSES_KEY = 'spec.storageClassName'
-const ACCESSMODE_KEY = 'spec.accessModes[0]'
+const ACCESSMODE_KEY = 'spec.accessModes'
 
 export default class VolumeSettings extends React.Component {
   static contextTypes = {
@@ -167,8 +167,16 @@ export default class VolumeSettings extends React.Component {
     const { storageClass, isLoading } = this.state
     const { editModalTitle, tabTitle } = this.props
     const storageClasses = this.getStorageClasses()
-    const supportedAccessModes = this.getSupportedAccessModes()
     const storageClassesList = this.store.list || {}
+
+    const supportedAccessModes =
+      this.getSupportedAccessModes() ?? Object.keys(ACCESS_MODES)
+    const supportedAccessModesSelectOptions = supportedAccessModes.map(
+      mode => ({
+        value: mode,
+        label: `${mode}: ${t(`ACCESS_MODE_${ACCESS_MODES[mode]}`)}`,
+      })
+    )
 
     return (
       <>
@@ -194,14 +202,14 @@ export default class VolumeSettings extends React.Component {
           <Form.Item
             label={t('ACCESS_MODE')}
             rules={[{ required: true, message: t('PARAM_REQUIRED') }]}
+            desc={t('ACCESS_MODES_DESC')}
           >
-            <AccessModes
+            <Select
               name={ACCESSMODE_KEY}
-              defaultValue={
-                get(supportedAccessModes, '[0]') || Object.keys(ACCESS_MODES)[0]
-              }
-              supportedAccessModes={supportedAccessModes}
+              options={supportedAccessModesSelectOptions}
               loading={isLoading}
+              defaultValue={[]}
+              multi
             />
           </Form.Item>
         ) : (

--- a/src/pages/clusters/containers/Storage/Volumes/Volume/index.jsx
+++ b/src/pages/clusters/containers/Storage/Volumes/Volume/index.jsx
@@ -195,9 +195,11 @@ export default class Volumes extends React.Component {
         dataIndex: 'capacity',
         isHideable: true,
         width: '12.32%',
-        render: (capacity, { accessMode }) => (
+        render: (capacity, { accessModes }) => (
           <div>
-            <p>{accessMode}</p>
+            {accessModes.map(mode => (
+              <p> {mode} </p>
+            ))}
           </div>
         ),
       },

--- a/src/pages/projects/containers/Volumes/index.jsx
+++ b/src/pages/projects/containers/Volumes/index.jsx
@@ -160,9 +160,11 @@ export default class Volumes extends React.Component {
         dataIndex: 'capacity',
         isHideable: true,
         width: '12.3%',
-        render: (capacity, { accessMode }) => (
+        render: (capacity, { accessModes }) => (
           <div className={styles.capacity}>
-            <p>{accessMode}</p>
+            {accessModes.map(mode => (
+              <p> {mode} </p>
+            ))}
           </div>
         ),
       },


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2183

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Change pvc access modes to list
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
<img width="778" alt="截屏2021-09-28 下午7 05 56" src="https://user-images.githubusercontent.com/51254187/135077282-74d686c1-55f9-4091-b331-a1f25f822b68.png">

