### PR TITLE
fix: The data is empty when create a app with template

### DIFF
--- a/src/pages/apps/components/AppBase/index.jsx
+++ b/src/pages/apps/components/AppBase/index.jsx
@@ -41,10 +41,14 @@ export default class AppBase extends React.PureComponent {
     const { className, app } = this.props
 
     const maintainers = safeParseJSON(
-      app.latest_app_version.maintainers,
+      get(app, 'latest_app_version.maintainers', []),
       []
     ).map(item => item.name)
-    const sources = safeParseJSON(app.latest_app_version.sources)
+
+    const sources = safeParseJSON(
+      get(app, 'latest_app_version.sources', []),
+      []
+    )
 
     return (
       <div className={classnames(styles.appBase, className)}>

--- a/src/pages/apps/components/Modals/AppCreate/index.jsx
+++ b/src/pages/apps/components/Modals/AppCreate/index.jsx
@@ -69,9 +69,7 @@ export default class AppCreate extends Component {
             <Button type={'control'} onClick={onOk}>
               {t('UPLOAD')}
             </Button>
-            <div className={styles.note}>
-              💁‍♂️ {` ${htmlLinkControl(htmlDes)}`}
-            </div>
+            <div className={styles.note}>💁‍♂️ {htmlLinkControl(htmlDes)}</div>
           </div>
         </ToggleView>
       </Modal>

--- a/src/pages/apps/components/Modals/HelmUpload/index.jsx
+++ b/src/pages/apps/components/Modals/HelmUpload/index.jsx
@@ -165,7 +165,7 @@ export default class HelmUpload extends Component {
             <div className={styles.configMask} />
           )}
         </div>
-        <div className={styles.note}>💁‍♂️ {` ${htmlLinkControl(htmlDes)}`}</div>
+        <div className={styles.note}>💁‍♂️ {htmlLinkControl(htmlDes)}</div>
       </div>
     )
   }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu_5@163.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
