### PR TITLE
feat: Hide the branch column if is not a multi-branch pipeline

### DIFF
--- a/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
@@ -73,6 +73,10 @@ export default class Activity extends React.Component {
     return this.props.match.params.branch
   }
 
+  get isMultiBranch() {
+    return this.store.detail.branchNames
+  }
+
   get prefix() {
     const { url } = this.props.match
     const _arr = url.split('/')
@@ -132,10 +136,9 @@ export default class Activity extends React.Component {
   handleRunning = debounce(async () => {
     const { detail } = this.store
     const { params } = this.props.match
-    const isMultibranch = detail.branchNames
     const hasParameters = detail.parameters && detail.parameters.length
 
-    if (isMultibranch || hasParameters) {
+    if (this.isMultiBranch || hasParameters) {
       this.trigger('pipeline.params', {
         devops: params.devops,
         cluster: params.cluster,
@@ -258,7 +261,9 @@ export default class Activity extends React.Component {
       width: '10%',
       render: commitId => (commitId && commitId.slice(0, 6)) || '-',
     },
-    ...(this.props.match.params.branch
+    // when it's in branch detail page, the branch column should be hidden
+    // when it's a non-multi-branch Pipeline, the branch column should be hidden
+    ...(this.isAtBranchDetailPage || !this.isMultiBranch
       ? []
       : [
           {
@@ -343,11 +348,10 @@ export default class Activity extends React.Component {
         ]
 
   renderFooter = () => {
-    const { detail, activityList } = this.store
+    const { activityList } = this.store
     const { total, limit } = activityList
-    const isMultibranch = detail.branchNames
 
-    if (!isMultibranch || this.isAtBranchDetailPage) {
+    if (!this.isMultiBranch || this.isAtBranchDetailPage) {
       return null
     }
 


### PR DESCRIPTION
…peline

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2321

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
