### PR TITLE
fix: can't access webpack port when dev using docker

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     command: yarn start
     ports:
       - 8000:8000
+      - 8001:8001
 
 volumes:
   nodemodules:


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What this PR does / why we need it:
Fixed an issue that the front-end could not be accessed normally because the docker container did not expose the port listened by webpack when developing with docker.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
