### PR TITLE
fix: Log detail highlight keyword is [Object Object]

### DIFF
--- a/src/components/Modals/LogSearch/Logging/Search/index.jsx
+++ b/src/components/Modals/LogSearch/Logging/Search/index.jsx
@@ -317,14 +317,10 @@ export default class LogSearchModal extends React.Component {
       return (
         <span
           dangerouslySetInnerHTML={{
-            __html: markedResult.map((log, index) =>
-              isString(log) ? (
-                log
-              ) : (
-                <span key={index} className={styles.hightLightMatch}>
-                  {log.hightLighted}
-                </span>
-              )
+            __html: markedResult.map(log =>
+              isString(log)
+                ? log
+                : `<span class="${styles.hightLightMatch}">${log.hightLighted}</span>`
             ),
           }}
         />

--- a/src/pages/clusters/containers/Gateway/Detail/GatewayLog/index.jsx
+++ b/src/pages/clusters/containers/Gateway/Detail/GatewayLog/index.jsx
@@ -194,14 +194,10 @@ export default class GatewayLog extends React.Component {
       return (
         <span
           dangerouslySetInnerHTML={{
-            __html: markedResult.map((log, index) =>
-              isString(log) ? (
-                log
-              ) : (
-                <span key={index} className={styles.hightLightMatch}>
-                  {log.hightLighted}
-                </span>
-              )
+            __html: markedResult.map(log =>
+              isString(log)
+                ? log
+                : `<span class="${styles.hightLightMatch}">${log.hightLighted}</span>`
             ),
           }}
         />


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2464,##2250

### Special notes for reviewers:

![截屏2021-11-12 14 29 05](https://user-images.githubusercontent.com/33231138/141420882-31f8d824-b5af-473c-97a5-34dae10952d3.png)

![截屏2021-11-12 14 32 43](https://user-images.githubusercontent.com/33231138/141421210-24134ae1-5716-41e4-88d6-d7d7aade4128.png)


### Does this PR introduced a user-facing change?
```release-note
Log matched keywords highlight is [Object Object].
```

### Additional documentation, usage docs, etc.:
