### PR TITLE
fix: Configmap's secret text too long

### DIFF
--- a/src/components/Base/List/index.scss
+++ b/src/components/Base/List/index.scss
@@ -67,6 +67,7 @@
 
 .texts {
   display: flex;
+  overflow: hidden;
 }
 
 .text {


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug



### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #[#4388](https://github.com/kubesphere/kubesphere/issues/4388)

### Special notes for reviewers:

![截屏2021-11-12 15 26 24](https://user-images.githubusercontent.com/33231138/141427149-f05d0814-c2f8-4926-b065-1b7e77650465.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
