### PR TITLE
fix: Update project available quota when editing project quota

### DIFF
--- a/src/pages/fedprojects/containers/Overview/LimitRange/index.jsx
+++ b/src/pages/fedprojects/containers/Overview/LimitRange/index.jsx
@@ -49,11 +49,14 @@ export default class LimitRange extends Component {
   }
 
   showSetting = () => {
+    const { namespace, workspace } = this.params
     const limitRanges = this.store.list.data
     this.trigger('project.default.resource', {
       ...this.params,
       detail: limitRanges[0],
       isFederated: true,
+      workspace,
+      name: namespace,
       projectDetail: this.props.projectStore.detail,
       success: () => this.setState({ showTip: false }),
     })

--- a/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/index.jsx
+++ b/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/index.jsx
@@ -50,9 +50,9 @@ export default class ResourceQuota extends React.Component {
   }
 
   showEdit = () => {
-    const { namespace, cluster } = this.props
+    const { namespace, cluster, workspace } = this.props
     this.trigger('project.quota.edit', {
-      detail: { name: namespace, namespace, cluster: cluster.name },
+      detail: { name: namespace, namespace, cluster: cluster.name, workspace },
       success: this.fetchData,
       isFederated: true,
     })


### PR DESCRIPTION
### What type of PR is this?
/kind bug


### What this PR does / why we need it:

At before，the available quota is the workspace lefted quota, it is Incorrect，the project available quota should be the sum of workspace lefted quota and project used.

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
the workspace in shire cluster total quota is: 
   limits.cpu:  2 Core
   limits.memory: 6G

the lcj-test-shire namespace total quota is:
   limits.cpu:  1 Core
   limits.memory: 2G

the workload that we created quota is:
   limits.cpu:  0.5 Core
   limits.memory: 1G

https://user-images.githubusercontent.com/33231138/141942391-b61b01ef-6f09-4378-97ab-a87c0cdb737d.mov


At before, if we create a workload as the video shown, the available quota as follows:
![截屏2021-11-16 15 46 35](https://user-images.githubusercontent.com/33231138/141942584-c829b4ee-356c-4767-b2de-de545d976d43.png)

### Does this PR introduced a user-facing change?
```release-note
Project avaliable quota inccrect. It should be the sum of workspace remaining quota and project used quota. 
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
