### PR TITLE
feat: Add avalibale quota tip when edting project resource default quota

### DIFF
--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -200,6 +200,9 @@ export default {
         store,
         detail,
         supportGpuSelect: true,
+        namespace,
+        cluster,
+        isFederated,
         ...props,
       })
     },

--- a/src/pages/fedprojects/containers/BaseInfo/index.jsx
+++ b/src/pages/fedprojects/containers/BaseInfo/index.jsx
@@ -79,7 +79,9 @@ class BaseInfo extends React.Component {
   get itemActions() {
     const { detail } = this.store
     const limitRanges = toJS(this.limitRangeStore.list.data)
-
+    const clusters = toJS(this.props.projectStore.detail.clusters).map(
+      cluster => cluster.name
+    )
     const actions = [
       {
         key: 'edit',
@@ -117,6 +119,7 @@ class BaseInfo extends React.Component {
             detail: get(limitRanges, 0, {}),
             isFederated: true,
             projectDetail: detail,
+            clusters,
             success: () => this.limitRangeStore.fetchListByK8s(this.params),
           }),
       },

--- a/src/pages/fedprojects/containers/Overview/LimitRange/index.jsx
+++ b/src/pages/fedprojects/containers/Overview/LimitRange/index.jsx
@@ -48,6 +48,12 @@ export default class LimitRange extends Component {
     return get(this.props.match, 'params', {})
   }
 
+  get clusters() {
+    return get(this.props.projectStore, 'detail.clusters', []).map(
+      cluster => cluster.name
+    )
+  }
+
   showSetting = () => {
     const { namespace, workspace } = this.params
     const limitRanges = this.store.list.data
@@ -57,6 +63,7 @@ export default class LimitRange extends Component {
       isFederated: true,
       workspace,
       name: namespace,
+      clusters: this.clusters,
       projectDetail: this.props.projectStore.detail,
       success: () => this.setState({ showTip: false }),
     })

--- a/src/pages/projects/components/Modals/DefaultResourceEdit/index.jsx
+++ b/src/pages/projects/components/Modals/DefaultResourceEdit/index.jsx
@@ -16,12 +16,16 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get } from 'lodash'
+import { get, mergeWith, isUndefined, omit, min, reduce } from 'lodash'
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import { Modal } from 'components/Base'
 import { ResourceLimit } from 'components/Inputs'
+import QuotaStore from 'stores/quota'
+import WorkspaceQuotaStore from 'stores/workspace.quota'
+import { toJS } from 'mobx'
+import { cpuFormat, memoryFormat, resourceLimitKey } from 'utils'
 
 export default class DefaultResourceEditModal extends React.Component {
   static propTypes = {
@@ -45,10 +49,18 @@ export default class DefaultResourceEditModal extends React.Component {
   constructor(props) {
     super(props)
 
+    this.quotaStore = new QuotaStore()
+    this.workspaceQuotaStore = new WorkspaceQuotaStore()
+
     this.state = {
       data: get(props.detail, 'limit', {}),
       error: '',
+      availableQuota: {},
     }
+  }
+
+  componentDidMount() {
+    this.fetchQuota()
   }
 
   componentDidUpdate(prevProps) {
@@ -86,6 +98,154 @@ export default class DefaultResourceEditModal extends React.Component {
 
   handleError = error => this.setState({ error })
 
+  availableQuota_memory = (data = {}) => {
+    const newData = { ...data }
+    Object.keys(data).forEach(key => {
+      if (key.endsWith('memory')) {
+        newData[key] = memoryFormat(data[key])
+      }
+      if (key.endsWith('cpu')) {
+        newData[key] = cpuFormat(data[key])
+      }
+    })
+    return newData
+  }
+
+  singleClusterQuota = (workspace, namespace, cluster) => {
+    return new Promise(resolve => {
+      Promise.all([
+        this.quotaStore.fetch({
+          cluster,
+          namespace,
+        }),
+        this.workspaceQuotaStore.fetchDetail({
+          name: workspace,
+          workspace,
+          cluster,
+        }),
+      ]).then(() => {
+        const workspaceQuota = toJS(
+          get(this.workspaceQuotaStore.detail, 'status.total.hard')
+        )
+        const namespaceQuota = toJS(this.quotaStore.data.hard)
+        resolve({
+          workspaceQuota: this.availableQuota_memory(workspaceQuota),
+          namespaceQuota: this.availableQuota_memory(namespaceQuota),
+        })
+      })
+    })
+  }
+
+  multiClusterQuota = (workspace, namespace) => {
+    const fetchArr = []
+    const defaults = {
+      'limits.cpu': undefined,
+      'limits.memory': undefined,
+    }
+    this.props.clusters.forEach(cluster =>
+      fetchArr.push(this.singleClusterQuota(workspace, namespace, cluster))
+    )
+    Promise.all(fetchArr).then(AllClusterQuota => {
+      const workspaceQuotas = AllClusterQuota.map(item =>
+        get(item, 'workspaceQuota', defaults)
+      )
+      const namespaceQuotas = AllClusterQuota.map(item =>
+        get(item, 'namespaceQuota', defaults)
+      )
+      const gpuQuotas = AllClusterQuota.map(item =>
+        omit(get(item, 'namespaceQuota', {}), resourceLimitKey)
+      )
+      this.setState({
+        availableQuota: {
+          workspace: this.transformQuota(workspaceQuotas),
+          namespace: {
+            ...this.transformQuota(namespaceQuotas),
+            ...this.transformGpu(gpuQuotas),
+          },
+        },
+      })
+    })
+  }
+
+  transformQuota = data => {
+    return {
+      'limits.cpu': this.findCpuOrMemoryMin(data, 'limits.cpu'),
+      'limits.memory': this.findCpuOrMemoryMin(data, 'limits.memory'),
+      'requests.cpu': this.findCpuOrMemoryMin(data, 'requests.cpu'),
+      'requests.memory': this.findCpuOrMemoryMin(data, 'requests.memory'),
+    }
+  }
+
+  findCpuOrMemoryMin = (dataArr, key) => {
+    const toArr = dataArr.map(item => item[key])
+    return min(toArr)
+  }
+
+  transformGpu = data => {
+    return reduce(
+      data,
+      (total, current) => {
+        const hasKey = get(total, `${Object.keys(current)[0]}`)
+        if (hasKey) {
+          return Number(hasKey) > Number(Object.values(current)[0])
+            ? { ...total, ...current }
+            : { ...total }
+        }
+        return { ...total, ...current }
+      },
+      {}
+    )
+  }
+
+  fetchQuota = async () => {
+    const { workspace, cluster, namespace, isFederated } = this.props
+
+    if (!isFederated) {
+      const leftQuota = await this.singleClusterQuota(
+        workspace,
+        namespace,
+        cluster
+      )
+      this.setState({
+        availableQuota: {
+          workspace: get(leftQuota, 'workspaceQuota'),
+          namespace: get(leftQuota, 'namespaceQuota'),
+        },
+      })
+    } else {
+      this.multiClusterQuota(workspace, namespace)
+    }
+  }
+
+  getQuotaInfo = path => get(this.workspaceQuota, path, undefined)
+
+  get workspaceQuota() {
+    const nsQuota = get(this.state.availableQuota, 'namespace', {})
+    const wsQuota = get(this.state.availableQuota, 'workspace', {})
+    return mergeWith(nsQuota, wsQuota, (ns, ws) => {
+      if (!ns && !ws) {
+        return undefined
+      }
+      if (!isUndefined(ns)) {
+        return ns
+      }
+      return ws
+    })
+  }
+
+  get workspaceLimitProps() {
+    return {
+      limits: {
+        cpu: this.getQuotaInfo('limits.cpu'),
+        memory: this.getQuotaInfo('limits.memory'),
+      },
+      requests: {
+        cpu: this.getQuotaInfo('requests.cpu'),
+        memory: this.getQuotaInfo('requests.memory'),
+      },
+    }
+  }
+
   render() {
     const { visible, onCancel, isSubmitting } = this.props
     const { error } = this.state
@@ -105,6 +265,7 @@ export default class DefaultResourceEditModal extends React.Component {
           onChange={this.handleChange}
           onError={this.handleError}
           supportGpuSelect={this.props.supportGpuSelect || false}
+          workspaceLimitProps={this.workspaceLimitProps}
         />
       </Modal>
     )


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

The project resource default quota maximum should be the smallest of workspace lefted quota and namespace quota limit.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
The workspace lcj-auto-quota's has two single cluster project in it: test2、lcj-test1. 
The quota of cluster rohan as follows:
   requests.cpu: 1 Core   requests.memory: 1 G
   limits.cpu: 4 Core     limits.cpu: 8 Core

the lcj-test1 project quota is: 
   request.cpu: 0.9 Core  reqests.memory: Not limit
   limits.cpu: Not limit  limits.cpu: 6.5 Core

so container default quota maximum is : 
   request.cpu: 0.9 Core  reqests.memory: 1 G
   limits.cpu: 4 Core     limits.cpu: 6.5 G

For multi cluster project, it also work on this, It will compares all cluster quota limit.
```

https://user-images.githubusercontent.com/33231138/142144509-e68985da-dff6-4dce-a0cc-8cc829a679f7.mov

### Does this PR introduced a user-facing change?
```release-note
Add avaliable quota tip when edting project resource default quota.
```

### Additional documentation, usage docs, etc.:
