### PR TITLE
feat: Add status filter in pods manage page

### DIFF
--- a/src/pages/clusters/containers/Workload/Pods/index.jsx
+++ b/src/pages/clusters/containers/Workload/Pods/index.jsx
@@ -27,7 +27,7 @@ import StatusReason from 'projects/components/StatusReason'
 import ResourceTable from 'clusters/components/ResourceTable'
 
 import { getLocalTime } from 'utils'
-import { POD_STATUS, ICON_TYPES } from 'utils/constants'
+import { ICON_TYPES, PODS_STATUS } from 'utils/constants'
 
 import PodStore from 'stores/pod'
 
@@ -73,13 +73,6 @@ export default class Pods extends React.Component {
     ]
   }
 
-  getStatus() {
-    return POD_STATUS.map(status => ({
-      text: t(status.text),
-      value: status.value,
-    }))
-  }
-
   getItemDesc = record => {
     const { status, type } = record.podStatus
     const desc =
@@ -97,6 +90,13 @@ export default class Pods extends React.Component {
     return desc
   }
 
+  getPodsStatus() {
+    return PODS_STATUS.map(status => ({
+      text: t(status.text),
+      value: status.value,
+    }))
+  }
+
   getColumns = () => {
     const { getSortOrder } = this.props
     return [
@@ -107,6 +107,17 @@ export default class Pods extends React.Component {
         sortOrder: getSortOrder('name'),
         search: true,
         render: this.renderAvatar,
+      },
+      {
+        title: t('STATUS'),
+        dataIndex: 'status',
+        filters: this.getPodsStatus(),
+        isHideable: true,
+        search: true,
+        with: '5%',
+        render: (_, { podStatus }) => (
+          <span>{t(podStatus.type.toUpperCase())}</span>
+        ),
       },
       {
         title: t('NODE_SI'),
@@ -184,6 +195,7 @@ export default class Pods extends React.Component {
           {...tableProps}
           itemActions={this.itemActions}
           columns={this.getColumns()}
+          hideColumn={['status']}
           onCreate={null}
           cluster={match.params.cluster}
         />

--- a/src/pages/projects/containers/Pods/index.jsx
+++ b/src/pages/projects/containers/Pods/index.jsx
@@ -27,7 +27,7 @@ import { withProjectList, ListPage } from 'components/HOCs/withList'
 import StatusReason from 'projects/components/StatusReason'
 
 import { getLocalTime } from 'utils'
-import { POD_STATUS, ICON_TYPES } from 'utils/constants'
+import { POD_STATUS, ICON_TYPES, PODS_STATUS } from 'utils/constants'
 
 import PodStore from 'stores/pod'
 
@@ -96,6 +96,13 @@ export default class Pods extends React.Component {
     return desc
   }
 
+  getPodsStatus() {
+    return PODS_STATUS.map(status => ({
+      text: t(status.text),
+      value: status.value,
+    }))
+  }
+
   getColumns = () => {
     const { getSortOrder } = this.props
     return [
@@ -106,6 +113,16 @@ export default class Pods extends React.Component {
         sortOrder: getSortOrder('name'),
         search: true,
         render: this.renderAvatar,
+      },
+      {
+        title: t('STATUS'),
+        dataIndex: 'status',
+        filters: this.getPodsStatus(),
+        isHideable: true,
+        search: true,
+        render: (_, { podStatus }) => (
+          <span>{t(podStatus.type.toUpperCase())}</span>
+        ),
       },
       {
         title: t('Node'),
@@ -190,6 +207,7 @@ export default class Pods extends React.Component {
           {...tableProps}
           itemActions={this.itemActions}
           columns={this.getColumns()}
+          hideColumn={['status']}
           onCreate={null}
         />
       </ListPage>

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -28,6 +28,14 @@ export const POD_STATUS = [
   { text: 'Terminated', value: 'terminated' },
 ]
 
+export const PODS_STATUS = [
+  { text: 'Pending', value: 'Pending' },
+  { text: 'Running', value: 'Running' },
+  { text: 'Completed', value: 'Succeeded' },
+  { text: 'Failed', value: 'Failed' },
+  { text: 'Unknown', value: 'Unknown' },
+]
+
 export const JOB_STATUS = [
   { text: 'Failed', value: 'failed' },
   { text: 'Completed', value: 'completed' },


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <33231138+weili520@users.noreply.github.com>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2592

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/142154430-831dbf16-bc15-4d83-9fca-68bea7d739b1.mov

### Does this PR introduced a user-facing change?
```release-note
Support search pods by pod status in pods management page. 
```

### Additional documentation, usage docs, etc.:
