### PR TITLE
fix: Container log line too long

### DIFF
--- a/src/components/Cards/ContainerLog/index.scss
+++ b/src/components/Cards/ContainerLog/index.scss
@@ -53,7 +53,7 @@
     color: #b7c4d1;
     font-weight: 600;
     line-height: 20px;
-    white-space: pre;
+    white-space: pre-wrap;
 
     strong {
       color: $yellow;


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <33231138+weili520@users.noreply.github.com>

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##1257

### Special notes for reviewers:

![截屏2021-11-19 14 58 29](https://user-images.githubusercontent.com/33231138/142579061-ec434b78-c2fe-45c1-8b94-13ebb431c8f7.png)

### Does this PR introduced a user-facing change?
```release-note
Container log line too long when viewing container log deatil
```

### Additional documentation, usage docs, etc.:
