### PR TITLE
fix: Notification condition to add new tag validation rules

### DIFF
--- a/locales/en/notification.js
+++ b/locales/en/notification.js
@@ -43,6 +43,8 @@ module.exports = {
   'Please select a regex filter': 'Please select a regex filter',
   'Invalid notification condition': 'Invalid notification condition',
   TAG_INPUT_PLACEHOLDER: 'Please enter the value and press Enter to confirm',
+  PATTERN_TAG_INVALID_TIP:
+    'Invalid label. The label can contain only uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and dots (.), and must begin and end with an uppercase or lowercase letter or number.',
   INVALID_NOTIFICATION_CONDITION:
     'Please enter a correct notification condition.',
 

--- a/locales/es/notification.js
+++ b/locales/es/notification.js
@@ -45,6 +45,8 @@ module.exports = {
     'Seleccione un filtro de expresiones regulares',
   'Invalid notification condition': 'Condición de notificación no válida',
   TAG_INPUT_PLACEHOLDER: 'Ingrese el valor y presione Enter para confirmar',
+  PATTERN_TAG_INVALID_TIP:
+    'Invalid label. The label can contain only uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and dots (.), and must begin and end with an uppercase or lowercase letter or number.',
   INVALID_NOTIFICATION_CONDITION:
     'Please enter a correct notification condition.',
 

--- a/locales/tc/notification.js
+++ b/locales/tc/notification.js
@@ -42,6 +42,8 @@ module.exports = {
   DOES_NOT_EXIST: 'Does not exist',
   'Please select a tag': '請選擇標簽',
   'Please select a regex filter': '請選擇過濾規則',
+  PATTERN_TAG_INVALID_TIP:
+    'Invalid label. The label can contain only uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and dots (.), and must begin and end with an uppercase or lowercase letter or number.',
   INVALID_NOTIFICATION_CONDITION: '請填寫正確的通知條件。',
 
   SEND_TEST_MESSAGE: '發送測試信息',

--- a/locales/zh/notification.js
+++ b/locales/zh/notification.js
@@ -43,6 +43,8 @@ module.exports = {
   'Please select a regex filter': '请选择过滤规则',
   'Invalid notification condition': '请填写正确的通知条件',
   TAG_INPUT_PLACEHOLDER: '请输入值后回车确认',
+  PATTERN_TAG_INVALID_TIP:
+    '标签无效。标签只能包含字母、数字、连字符（-）、下划线（_）和句点（.），必须以数字或字母开头和结尾。',
   INVALID_NOTIFICATION_CONDITION: '请填写正确的通知条件。',
 
   SEND_TEST_MESSAGE: '发送测试信息',

--- a/src/components/Forms/Notification/BaseForm/ConditionSelect/index.jsx
+++ b/src/components/Forms/Notification/BaseForm/ConditionSelect/index.jsx
@@ -23,7 +23,7 @@ import { Select, Input, Icon, Notify } from '@kube-design/components'
 import { TagInput } from 'components/Inputs'
 
 import { SEVERITY_LEVEL } from 'configs/alerting/metrics/rule.config'
-import { PATTERN_NAME } from 'utils/constants'
+import { PATTERN_TAG } from 'utils/constants'
 
 import styles from './index.scss'
 
@@ -119,8 +119,8 @@ export default class ConditionSelect extends React.Component {
 
   handleAddItem = () => {
     const { keyItems, keyName } = this.state
-    if (!PATTERN_NAME.test(keyName)) {
-      Notify.error({ content: t('PATTERN_NAME_INVALID_TIP') })
+    if (!PATTERN_TAG.test(keyName)) {
+      Notify.error({ content: t('PATTERN_TAG_INVALID_TIP') })
       return
     }
     this.setState({
@@ -147,7 +147,7 @@ export default class ConditionSelect extends React.Component {
     this.props.onChange({
       key,
       operator,
-      values,
+      values: ['Exists', 'DoesNotExist'].includes(operator) ? [] : values,
     })
   }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -512,6 +512,7 @@ export const PATTERN_IMAGE_NAME = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?((\.|\/)[a-z0-9
 export const PATTERN_SERVICE_NAME = /^[a-z]([-a-z0-9]*[a-z0-9])?$/
 export const PATTERN_SERVICE_VERSION = /^[a-z0-9]*$/
 export const PATTERN_LABEL = /(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?/
+export const PATTERN_TAG = /^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/
 export const PATTERN_PASSWORD = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^]{6,64}$/
 export const PATTERN_IMAGE = /^\S+$/
 export const PATTERN_PORT_NAME = /^[a-z]([-a-z0-9]*[a-z0-9])?$/


### PR DESCRIPTION
Signed-off-by: xuliwenwenwen <liwenxu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
