### PR TITLE
fix: The UI text on the Service Monitoring Exporter page goes out of box

### DIFF
--- a/src/pages/projects/components/Modals/ServiceMonitor/Authorization/index.jsx
+++ b/src/pages/projects/components/Modals/ServiceMonitor/Authorization/index.jsx
@@ -187,6 +187,7 @@ export default class Authorization extends Component {
             <RadioGroup
               mode="button"
               value={authType}
+              wrapClassName={styles.dirCheck}
               options={this.authTypes}
               onChange={this.handleTypeChange}
             />

--- a/src/pages/projects/components/Modals/ServiceMonitor/Authorization/index.scss
+++ b/src/pages/projects/components/Modals/ServiceMonitor/Authorization/index.scss
@@ -72,3 +72,11 @@
     color: $blue-color03;
   }
 }
+
+.dirCheck {
+  :global {
+    label.radio-button {
+      height: 47px;
+    }
+  }
+}


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Please see the issue #2647

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2647

### Special notes for reviewers:
![image](https://user-images.githubusercontent.com/35127166/143173815-e1da98a7-216c-40b8-b44b-8b4b0340c30e.png)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

