### PR TITLE
fix: Can't update volume for deloyment

### DIFF
--- a/src/components/Cards/Volumes/Item.jsx
+++ b/src/components/Cards/Volumes/Item.jsx
@@ -132,10 +132,11 @@ const Card = ({ volume, match, isMultiProject }) => {
     </div>
   )
 
+  const titleName = get(volume, 'mountName', volume.name)
   return (
     <List.Item
       icon={icon}
-      title={volume.name}
+      title={titleName}
       titleClass={styles.title}
       description={description}
       extras={mount}

--- a/src/components/Forms/Workload/VolumeSettings/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/index.jsx
@@ -209,7 +209,7 @@ class VolumeSettings extends React.Component {
     this.checkMaxUnavalable(volumes)
   }
 
-  updateVolumeMounts = newVolumeMounts => {
+  updateVolumeMounts = (newVolumeMounts, omitEditVolume) => {
     const containers = get(
       this.fedFormTemplate,
       `${this.prefix}spec.containers`,
@@ -245,6 +245,12 @@ class VolumeSettings extends React.Component {
           )
         } else {
           container.volumeMounts.push(newVolumeMount)
+        }
+
+        if (omitEditVolume && omitEditVolume.name !== existVolume.name) {
+          container.volumeMounts = container.volumeMounts.filter(
+            item => item.name !== omitEditVolume.name
+          )
         }
 
         container.volumeMounts = container.volumeMounts
@@ -411,7 +417,7 @@ class VolumeSettings extends React.Component {
     )
   }
 
-  handleVolume(newVolume = {}, newVolumeMounts = []) {
+  handleVolume(newVolume = {}, newVolumeMounts = [], omitEditVolume) {
     if (!newVolume.uid) {
       newVolumeMounts.forEach(vm => {
         vm.name = newVolume.name
@@ -419,7 +425,7 @@ class VolumeSettings extends React.Component {
     }
 
     this.updateVolumes(newVolume)
-    this.updateVolumeMounts(newVolumeMounts)
+    this.updateVolumeMounts(newVolumeMounts, omitEditVolume)
     this.updateLogConfigs(newVolumeMounts)
 
     this.resetState()


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>


### What type of PR is this?
/kind bug

### What this PR does / why we need it:

At before, we can't switch the type of mounted volume for deolyment, because the update volume didn't  be removed from the deloyment spec.

### Which issue(s) this PR fixes:
Fixes ##2467,##2505,##2345

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/143185226-a14b2f34-67c2-4d28-8655-f960a632f365.mov

### Does this PR introduced a user-facing change?
```release-note
Update volume info for deolyment failed.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
