### PR TITLE
fix: Remove the invalid parameter template in the service edit mode

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -237,7 +237,9 @@ export const updateLabels = (template, module, value) => {
     set(formTemplate, 'spec.jobTemplate.metadata.labels', value)
   }
 
-  if (['ingresses', 'persistentvolumeclaims'].indexOf(module) === -1) {
+  if (
+    ['ingresses', 'persistentvolumeclaims', 'services'].indexOf(module) === -1
+  ) {
     set(formTemplate, 'spec.template.metadata.labels', value)
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2614

### Special notes for reviewers:
```
The problem is described in the process of editing services, 
the switch yaml file has invalid template parameter spec.template，
delete invalid parameters of services in the filtered resource template 
```
![](https://user-images.githubusercontent.com/27723125/141943312-1b9ed564-52cc-4218-9c25-c52f3f6eb6aa.png)
```
After modification, the invalid parameters in the red box above will no longer be displayed 
```
### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
