### PR TITLE
fix: Update gpu limit number verification rule

### DIFF
--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -492,7 +492,7 @@ export default class ResourceLimit extends React.Component {
     if (value === '') {
       inputNum = ''
     } else {
-      const number = /^[0-9]*$/.exec(value)
+      const number = /^(0|[1-9][0-9]*)$/.exec(value)
       inputNum = number == null ? get(this.state, 'gpu.value', '') : number[0]
     }
     this.setState(


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Now, user can't input the number like '01'.

### Which issue(s) this PR fixes:
Fixes ##2484

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
