### PR TITLE
fix: User can't open container terminal

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -446,7 +446,7 @@ export const getBrowserLang = () => {
     return 'en'
   }
 
-  return globals.config.defaultLang || 'en'
+  return get(globals, 'config.defaultLang', 'en')
 }
 
 export const toPromise = func =>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

User can't enter ther container terminal page when the browser language is not en, zh and zh-tw

<img width="885" alt="截屏2021-12-01 14 06 23" src="https://user-images.githubusercontent.com/33231138/144180960-7ea7be69-0757-4f03-a6bd-e6e532448de1.png">

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:

### Does this PR introduced a user-facing change?
```release-note
User can't enter ther container terminal page when the browser language is not en, zh and zh-tw.
```

### Additional documentation, usage docs, etc.:
