### PR TITLE
fix: Certificate verification problem

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -28,8 +28,8 @@ server:
   apiServer:
     clientID: kubesphere
     clientSecret: kubesphere
-    url: http://192.168.16.113:31076
-    wsUrl: ws://192.168.16.113:31076
+    url: http://ks-apiserver
+    wsUrl: ws://ks-apiserver
 
   # docker image search default url
   dockerHubUrl: https://hub.docker.com

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -28,8 +28,8 @@ server:
   apiServer:
     clientID: kubesphere
     clientSecret: kubesphere
-    url: http://ks-apiserver
-    wsUrl: ws://ks-apiserver
+    url: http://192.168.16.113:31076
+    wsUrl: ws://192.168.16.113:31076
 
   # docker image search default url
   dockerHubUrl: https://hub.docker.com

--- a/src/components/Forms/Pipelines/RepoSelect/GithubForm/index.jsx
+++ b/src/components/Forms/Pipelines/RepoSelect/GithubForm/index.jsx
@@ -157,11 +157,13 @@ export default class GitHubForm extends React.Component {
 
   getCredentialsList = () => {
     return [
-      ...this.props.store.credentials.data.map(credential => ({
-        label: credential.name,
-        value: credential.name,
-        type: credential.type,
-      })),
+      ...this.props.store.credentials.data
+        .map(credential => ({
+          label: credential.name,
+          value: credential.name,
+          type: credential.type,
+        }))
+        .filter(credential => credential.type === 'username_password'),
     ]
   }
 


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
Please see #2696. 
When verify credential, only display the type is equip to `username_password` 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2696

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
