### PR TITLE
fix: Resource Monitor Modal selected time range does not work

### DIFF
--- a/src/components/Modals/Monitoring/ApplicationResource/index.jsx
+++ b/src/components/Modals/Monitoring/ApplicationResource/index.jsx
@@ -62,6 +62,7 @@ export default class ResourceMonitorModal extends React.Component {
         ? this.workspaceStore.cluster
         : get(props, 'cluster', ''),
       namespace: get(props.detail, 'namespace', 'all'),
+      ...MonitorOptions,
     }
 
     this.projectStore = new ProjectStore()
@@ -157,12 +158,28 @@ export default class ResourceMonitorModal extends React.Component {
   }
 
   handleSubmit = () => {
+    const { times, step } = this.state
     const formData = this.formRef.current && this.formRef.current.getData()
     this.setState(formData, () => {
       this.fetchData({
         ...formData,
-        ...MonitorOptions,
+        times,
+        step,
       })
+    })
+  }
+
+  onCancel = () => {
+    this.setState({
+      ...MonitorOptions,
+    })
+    this.props.onCancel()
+  }
+
+  updateMonitorOptions = ({ times, step }) => {
+    this.setState({
+      times,
+      step,
     })
   }
 
@@ -303,7 +320,8 @@ export default class ResourceMonitorModal extends React.Component {
   }
 
   render() {
-    const { visible, onCancel } = this.props
+    const { times, step } = this.state
+    const { visible } = this.props
     const { isLoading, isRefreshing } = this.monitorStore.resourceMetrics
 
     if (!visible) return null
@@ -312,10 +330,12 @@ export default class ResourceMonitorModal extends React.Component {
       <ControllerModal
         visible={visible}
         onFetch={this.fetchData}
-        onCancel={onCancel}
+        onCancel={this.onCancel}
         loading={isLoading}
         refreshing={isRefreshing}
-        {...MonitorOptions}
+        times={times}
+        step={step}
+        updateMonitorOptions={this.updateMonitorOptions}
       >
         <div className={styles.content}>
           {this.renderFilterForm()}

--- a/src/components/Modals/Monitoring/Controller/index.jsx
+++ b/src/components/Modals/Monitoring/Controller/index.jsx
@@ -22,6 +22,8 @@ import PropTypes from 'prop-types'
 import { Controller as Base } from 'components/Cards/Monitoring'
 import { Button, Icon, Loading } from '@kube-design/components'
 import { Modal } from 'components/Base'
+import { get } from 'lodash'
+import { stopAutoRefresh } from 'utils/monitoring'
 
 import styles from './index.scss'
 
@@ -53,6 +55,19 @@ export default class MonitoringModalController extends Base {
 
   init() {
     this.initParams(this.props)
+  }
+
+  handleChange = data => {
+    const updateMonitorOptions = get(this.props, 'updateMonitorOptions', false)
+    this.params = data
+    updateMonitorOptions && this.props.updateMonitorOptions(data)
+
+    const enableAutoRefresh =
+      !data.start && !data.end && this.props.enableAutoRefresh
+    this.setState({ enableAutoRefresh, autoRefresh: false }, () => {
+      stopAutoRefresh(this)
+      this.fetchData()
+    })
   }
 
   renderCustomActions() {


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Resource Monitor Modal selected time range does not work.

### Which issue(s) this PR fixes:
Fixes ##2674 

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/144350615-97e74df8-7a79-4231-b41b-462f898997c2.mov

### Does this PR introduced a user-facing change?
```release-note
Resource Monitor Modal selected time range does not work.
```

### Additional documentation, usage docs, etc.:
