### PR TITLE
fix: Failed to create a statefulSet with a volume template added

### DIFF
--- a/src/components/Forms/Workload/VolumeSettings/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/index.jsx
@@ -359,7 +359,7 @@ class VolumeSettings extends React.Component {
       this.fedFormTemplate,
       `${this.prefix}spec.containers`,
       []
-    ).map(c => ({ ...c, type: 'work' }))
+    ).map(c => ({ ...c, type: 'worker' }))
     const initContainers = get(
       this.fedFormTemplate,
       `${this.prefix}spec.initContainers`,


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##[4432](https://github.com/kubesphere/kubesphere/issues/4432)

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/144388003-d993f6f6-78ac-46fe-a134-8109b5f475d0.mov

### Does this PR introduced a user-facing change?
```release-note
Failed to create a statefulSet with a volume template added.
```

### Additional documentation, usage docs, etc.:
