### PR TITLE
fix: Terminal log 403 error if user not login

### DIFF
--- a/server/services/session.js
+++ b/server/services/session.js
@@ -249,6 +249,9 @@ const getKSConfig = async token => {
 const getK8sRuntime = async ctx => {
   const token = ctx.cookies.get('token')
   let resp = 'docker'
+  if (!token) {
+    return resp
+  }
   try {
     const nodeList = await send_gateway_request({
       method: 'GET',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
If user not login, the terminal will log an error as follows:
```
{
  code: 403,
  kind: 'Status',
  apiVersion: 'v1',
  metadata: {},
  status: 'Failure',
  message: 'nodes is forbidden: User "system:anonymous" cannot list resource "nodes" in API group "" at the cluster scope',
  reason: 'Forbidden',
  details: { kind: 'nodes' },
  statusText: 'Forbidden'
}
```
![image](https://user-images.githubusercontent.com/33231138/145163600-9c6ed5d8-11fa-4453-9ccb-62721cb55d97.png)

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
