### PR TITLE
fix: Incorrect information for exceeding the resource limit

### DIFF
--- a/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
@@ -30,6 +30,9 @@ module.exports = {
     'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  QUOTA_UNSET_TIP: 'Resource occupation is unset',
+  QUOTA_OVERCOST_TIP:
+    'The current resource occupation has exceeded the remaining',
 
   // List > Create > Pod Settings > Port Settings
   WORKLOAD_PORT_NAME_DESC:

--- a/src/components/Forms/Workload/ContainerSettings/ContainerList/QuotaCheck.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerList/QuotaCheck.jsx
@@ -182,14 +182,23 @@ export default class QuotaCheck extends Component {
     if (isEmpty(containers) && isEmpty(initContainers)) {
       return null
     }
+    const limitUnset = Object.values(checkResult).some(
+      item => item.overcost === 'unset'
+    )
+    const overcost = Object.values(checkResult).some(
+      item => item.overcost === true
+    )
+    const type = overcost || limitUnset ? 'error' : 'info'
+    const title = overcost
+      ? t('QUOTA_OVERCOST_TIP')
+      : limitUnset
+      ? t('QUOTA_UNSET_TIP')
+      : t('Remaining Quota')
 
-    const overcost = Object.values(checkResult).some(item => item.overcost)
-    const type = overcost ? 'error' : 'info'
-    const title = overcost ? t('QUOTA_OVERCOST_TIP') : t('Remaining Quota')
-
-    const message = overcost
-      ? this.renderOverCostMessage(checkResult)
-      : this.renderQuotaMessage(checkResult)
+    const message =
+      overcost || limitUnset
+        ? this.renderOverCostMessage(checkResult)
+        : this.renderQuotaMessage(checkResult)
 
     return (
       <Alert

--- a/src/utils/workload.js
+++ b/src/utils/workload.js
@@ -372,7 +372,10 @@ export const compareQuotaAndResources = (leftQuota, resources) => {
         namespaceQuota === Infinity ? undefined : `${namespaceQuota}${unit}`,
       workspaceQuota:
         workspaceQuota === Infinity ? undefined : `${workspaceQuota}${unit}`,
-      overcost: cost > workspaceQuota || cost > namespaceQuota,
+      overcost:
+        cost === Infinity
+          ? 'unset'
+          : cost > workspaceQuota || cost > namespaceQuota,
     }
   })
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

Now, if the user didn't set a resource limit for the container, the tip title will be 'Resource occupation is unset', and if the limit setting is beyond the available quota, the title will be 'The current resource occupation has exceeded the remaining'.

### Which issue(s) this PR fixes:
Fixes ##2672

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/145358264-5f001d15-e88f-4a38-9d94-746e7f7b7894.mov


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
