### PR TITLE
Fix CVE-2021-28831

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 
 # Prepare the build environment
-FROM node:12.18-alpine as builder
+FROM node:12-alpine3.14 as builder
 
 ARG YARN_VERSION=1.22.4
 
@@ -32,7 +32,7 @@ RUN mv /kubesphere/package.json /out/
 ##############
 # Final Image
 ##############
-FROM node:12.18-alpine as base_os_context
+FROM node:12-alpine3.14 as base_os_context
 
 RUN adduser -D -g kubesphere -u 1002 kubesphere && \
     mkdir -p /opt/kubesphere/console && \


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind flake

### What this PR does / why we need it:
Upgrade base image to `node:12-alpine3.14` to fix  CVE-2021-28831 in the docker base image

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
