### PR TITLE
fix failing docker build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -10,7 +10,7 @@ ARG YARN_VERSION=1.22.4
 WORKDIR /kubesphere
 ADD . /kubesphere/
 
-RUN apk add --no-cache --virtual .build-deps ca-certificates python python3 py3-pip make openssl g++ bash
+RUN apk add --no-cache --virtual .build-deps ca-certificates python2 python3 py3-pip make openssl g++ bash
 RUN npm install yarn@${YARN_VERSION}
 
 # If you have trouble downloading the yarn binary, try the following:


### PR DESCRIPTION
### What type of PR is this?

Add one of the following kinds:
/kind bug
/kind failing-test

### What this PR does / why we need it:
Dockerfile base image `node:12-alpine3.14` failed to install python2 https://prow.kubesphere.io/view/s3/prow-logs/logs/pull-console-build-image/1469202824981123072. 

Previously,  `app add python` to python2, but the package name renamed to python2 in `node:12-alpine3.14`.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
