### PR TITLE
fix: Notification condition filter custom tag value validation rules.

### DIFF
--- a/locales/en/l10n-platformSettings-notificationManagement-notificationConfiguration.js
+++ b/locales/en/l10n-platformSettings-notificationManagement-notificationConfiguration.js
@@ -49,6 +49,8 @@ module.exports = {
   TAG_INPUT_PLACEHOLDER: 'Please enter the value and press Enter to confirm',
   PATTERN_TAG_INVALID_TIP:
     'Invalid label. The label can contain only uppercase and lowercase letters, numbers, hyphens (-), underscores (_), and dots (.), and must begin and end with an uppercase or lowercase letter or number.',
+  PATTERN_TAG_VALUE_INVALID_TIP:
+    'Invalid label values. The label values can only contain uppercase and lowercase letters, numbers, hyphens (-), underscores (_) and dots (.) and must begin and end with an uppercase or lowercase letter or number and be a maximum of 63 characters.',
   INVALID_NOTIFICATION_CONDITION:
     'Please enter a correct notification condition.',
   SEND_TEST_MESSAGE: 'Send Test Message',

--- a/locales/zh/l10n-platformSettings-notificationManagement-notificationConfiguration.js
+++ b/locales/zh/l10n-platformSettings-notificationManagement-notificationConfiguration.js
@@ -19,7 +19,8 @@ module.exports = {
   // Banner
   NOTIFICATION_MANAGEMENT: '通知管理',
   NOTIFICATION_CONFIGURATION: '通知配置',
-  NOTIFICATION_CONFIGURATION_DESC: 'KubeSphere 支持多种通知渠道的通知配置，您可以进行服务器和接收配置，并开启或关闭通知。',
+  NOTIFICATION_CONFIGURATION_DESC:
+    'KubeSphere 支持多种通知渠道的通知配置，您可以进行服务器和接收配置，并开启或关闭通知。',
   NOTIFICATION_EMAIL: '邮件',
   // Email
   MAIL_TITLE: '邮件',
@@ -35,18 +36,23 @@ module.exports = {
   CONTAINER: '容器',
   VALUES: '值',
   CONDITION_OPERATOR: '操作符',
-  NOTIFICATION_CONDITION_SETTING_TIP: '操作符<b>包含值</b>和<b>不包含值</b>需要添加一个或多个标签值。使用回车分隔多个值。</br>操作符<b>存在</b>和<b>不存在</b>判断某个标签是否存在，无需设置标签值。',
+  NOTIFICATION_CONDITION_SETTING_TIP:
+    '操作符<b>包含值</b>和<b>不包含值</b>需要添加一个或多个标签值。使用回车分隔多个值。</br>操作符<b>存在</b>和<b>不存在</b>判断某个标签是否存在，无需设置标签值。',
   NOTIFICATION_CONDITION_SETTINGS_DESC: '您只会接收到符合条件的通知。',
   INCLUDES_VALUES: '包含值',
   DOES_NOT_INCLUDE_VALUES: '不包含值',
   EXISTS: '存在',
   DOES_NOT_EXIST: '不存在',
   TAG_INPUT_PLACEHOLDER: '请输入值后回车确认',
-  PATTERN_TAG_INVALID_TIP: '标签无效。标签只能包含字母、数字、连字符（-）、下划线（_）和句点（.），必须以数字或字母开头和结尾。',
+  PATTERN_TAG_INVALID_TIP:
+    '标签无效。标签只能包含字母、数字、连字符（-）、下划线（_）和句点（.），必须以数字或字母开头和结尾。',
+  PATTERN_TAG_VALUE_INVALID_TIP:
+    '标签值无效。标签值只能包含字母、数字、连字符（-）、下划线（_）和句点（.），必须以数字或字母开头和结尾，最长 63 个字符。',
   INVALID_NOTIFICATION_CONDITION: '请填写正确的通知条件。',
   SEND_TEST_MESSAGE: '发送测试信息',
   SEND_TEST_MESSAGE_DESC: '配置完成后，您可以发送测试信息进行验证。',
-  SEND_TEST_MESSAGE_SUCCESS_DESC: '验证成功。已向您发送了一条测试消息，请注意查收。',
+  SEND_TEST_MESSAGE_SUCCESS_DESC:
+    '验证成功。已向您发送了一条测试消息，请注意查收。',
   SMTP_SERVER_ADDRESS: 'SMTP 服务器地址',
   USE_SSL_SECURE_CONNECTION: '使用 SSL 安全连接',
   SENDER_EMAIL: '发件人邮箱',
@@ -63,7 +69,8 @@ module.exports = {
   ADDED_SUCCESS_DESC: '添加成功。',
   POD: '容器组',
   UPDATE_SUCCESSFUL: '更新成功。',
-  PATTERN_NAME_INVALID_TIP: '名称无效。名称只能包含小写字母、数字、或连字符（-）。',
+  PATTERN_NAME_INVALID_TIP:
+    '名称无效。名称只能包含小写字母、数字、或连字符（-）。',
   // DingTalk
   DINGTALK_TITLE: '钉钉',
   DingTalk: '钉钉',
@@ -72,7 +79,8 @@ module.exports = {
   // DingTalk > Conversation Settings
   CONVERSATION_SETTINGS: '会话设置',
   CONVERSATION_ID: '会话 ID',
-  CONVERSATION_ID_TIP: '会话 ID 需要系统管理员进行配置才能获取，如需设置请联系系统管理员。',
+  CONVERSATION_ID_TIP:
+    '会话 ID 需要系统管理员进行配置才能获取，如需设置请联系系统管理员。',
   DINGTALK_SETTING_TIP: '请设置会话或者群机器人。',
   ENTER_CONVERSATION_ID_DESC: '请输入会话 ID。',
   MAX_CID_COUNT: '您可以最多添加 {count} 个会话 ID。',
@@ -143,5 +151,5 @@ module.exports = {
   BASIC_AUTH: '基础认证',
   NO_AUTH: '无需认证',
   BEARER_TOKEN: 'Bearer 令牌',
-  TOKEN: '令牌'
-};
+  TOKEN: '令牌',
+}

--- a/src/components/Inputs/TagInput/autosuggest.jsx
+++ b/src/components/Inputs/TagInput/autosuggest.jsx
@@ -22,7 +22,7 @@ import { noop } from 'lodash'
 import AutosizeInput from 'react-input-autosize'
 import { Notify } from '@kube-design/components'
 
-import { PATTERN_NAME } from 'utils/constants'
+import { PATTERN_TAG } from 'utils/constants'
 
 import styles from './index.scss'
 
@@ -67,8 +67,8 @@ class Autosuggest extends Component {
 
     if (event.key === 'Enter') {
       if (value.trim() !== '') {
-        if (!PATTERN_NAME.test(value)) {
-          Notify.error({ content: t('PATTERN_NAME_INVALID_TIP') })
+        if (!PATTERN_TAG.test(value) || value.length > 63) {
+          Notify.error({ content: t('PATTERN_TAG_VALUE_INVALID_TIP') })
           return
         }
         this.setState({ value: '' }, () => {


### PR DESCRIPTION
Signed-off-by: xuliwenwenwen <liwenxu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##2816 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
