### PR TITLE
fix: Update container resource occupation validation strategy

### DIFF
--- a/src/components/Forms/Workload/ContainerSettings/ContainerList/QuotaCheck.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerList/QuotaCheck.jsx
@@ -18,7 +18,7 @@
 
 import React, { Component } from 'react'
 import isEqual from 'react-fast-compare'
-import { get, isEmpty } from 'lodash'
+import { get, isEmpty, isUndefined } from 'lodash'
 
 import { Alert } from '@kube-design/components'
 
@@ -53,6 +53,15 @@ export default class QuotaCheck extends Component {
       replicas
     )
     return compareQuotaAndResources(leftQuota, resourcesCost)
+  }
+
+  get hasLimitQuota() {
+    const { leftQuota } = this.props
+    let hasLimit = false
+    Object.keys(leftQuota).forEach(key => {
+      hasLimit = Object.values(leftQuota[key]).some(item => !isUndefined(item))
+    })
+    return hasLimit
   }
 
   renderOverCostMessage(result) {
@@ -183,20 +192,25 @@ export default class QuotaCheck extends Component {
       return null
     }
     const limitUnset = Object.values(checkResult).some(
-      item => item.overcost === 'unset'
+      item =>
+        (item.namespaceQuota || item.workspaceQuota) &&
+        item.overcost === 'unset'
     )
     const overcost = Object.values(checkResult).some(
       item => item.overcost === true
     )
-    const type = overcost || limitUnset ? 'error' : 'info'
-    const title = overcost
-      ? t('QUOTA_OVERCOST_TIP')
-      : limitUnset
-      ? t('QUOTA_UNSET_TIP')
-      : t('Remaining Quota')
+    const type =
+      (overcost || limitUnset) && this.hasLimitQuota ? 'error' : 'info'
+
+    const title =
+      overcost && this.hasLimitQuota
+        ? t('QUOTA_OVERCOST_TIP')
+        : limitUnset && this.hasLimitQuota
+        ? t('QUOTA_UNSET_TIP')
+        : t('Remaining Quota')
 
     const message =
-      overcost || limitUnset
+      (overcost || limitUnset) && this.hasLimitQuota
         ? this.renderOverCostMessage(checkResult)
         : this.renderQuotaMessage(checkResult)
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
> During creating a deployment, if the workspace or project has a quota limit, the container should also need to set resource limits, otherwise, we should give them an error tip. 

For example, the project `hello`'s project quota limit is as follows:
```
  requests.cpu: 1 core requests.memory: 2 Gi
  limits.cpu: 2 core   limits.memory: Not limited
```
and the container's default resource quota is:
```
 requests.cpu: 1 core requests.memory: 1 Gi
 limits.cpu: 4 core   limits.memory: 4 Gi 
```
so, if we don't update container's quota during creating deployment, the tip info should be this:

![截屏2021-12-14 17 05 57](https://user-images.githubusercontent.com/33231138/145967362-49fb7ee3-6083-4c04-ac8c-f579a025b616.png)

and then update it to:
```
requests.cpu: 1 core requests.memory: 1 Gi
limits.cpu: Not limited   limits.memory: 4 Gi
```
the tip should be as this:
![截屏2021-12-14 17 10 01](https://user-images.githubusercontent.com/33231138/145968057-82ba5ca3-2dd6-4eb4-8413-397d366b9027.png)

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/145969269-cfb9b554-a81b-4df5-bb32-4058071ef8e6.mov


### Does this PR introduced a user-facing change?
```release-note
Update container's resource occupation prompt during creating a deployment.
```

### Additional documentation, usage docs, etc.:
