### PR TITLE
fix: Gpu tip info error and gpu limit number error

### DIFF
--- a/server/config.yaml
+++ b/server/config.yaml
@@ -620,3 +620,7 @@ client:
       max_number_of_toTag: 20
     slack:
       max_number_of_channel: 20
+  
+  # supported Gpu type
+  supportGpuType:
+    - 'nvidia.com/gpu'

--- a/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
@@ -17,8 +17,8 @@
  */
 
 import React from 'react'
-import { get, isEmpty, omit } from 'lodash'
-import { generateId, parseDockerImage, resourceLimitKey } from 'utils'
+import { get, isEmpty } from 'lodash'
+import { generateId, parseDockerImage, gpuLimitsArr } from 'utils'
 
 import { PATTERN_NAME } from 'utils/constants'
 
@@ -80,19 +80,7 @@ export default class ContainerSetting extends React.Component {
   }
 
   getGpuLimit() {
-    const hard = this.props.workspaceQuota
-    return !isEmpty(omit(hard, resourceLimitKey))
-      ? {
-          type: Object.keys(omit(hard, resourceLimitKey))[0]
-            .split('.')
-            .slice(1)
-            .join('.'),
-          value: Number(Object.values(omit(hard, resourceLimitKey))[0]),
-        }
-      : {
-          type: '',
-          value: '',
-        }
+    return gpuLimitsArr(this.props.workspaceQuota)
   }
 
   get workspaceLimitProps() {

--- a/src/components/Forms/Workload/ContainerSettings/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/index.jsx
@@ -29,6 +29,8 @@ import {
   reduce,
   mergeWith,
   isUndefined,
+  pickBy,
+  endsWith,
 } from 'lodash'
 import React from 'react'
 import { generateId, getContainerGpu, resourceLimitKey } from 'utils'
@@ -275,8 +277,12 @@ export default class ContainerSetting extends React.Component {
   }
 
   transformGpu = data => {
+    const supportGpu = globals.config.supportGpuType
+    const gpuArr = data.map(item =>
+      pickBy(item, (_, key) => supportGpu.some(type => endsWith(key, type)))
+    )
     return reduce(
-      data,
+      gpuArr,
       (total, current) => {
         const hasKey = get(total, `${Object.keys(current)[0]}`)
         if (hasKey) {

--- a/src/components/Modals/QuotaEdit/Quotas/index.jsx
+++ b/src/components/Modals/QuotaEdit/Quotas/index.jsx
@@ -39,14 +39,6 @@ import { QUOTAS_KEY_MODULE_MAP } from './constants'
 
 import styles from './index.scss'
 
-const omitKey = [
-  'limits.cpu',
-  'limits.memory',
-  'requests.cpu',
-  'requests.memory',
-  'limits.nvidia.com/gpu',
-  'requests.nvidia.com/gpu',
-]
 export default class Quotas extends React.Component {
   constructor(props) {
     super(props)
@@ -64,8 +56,17 @@ export default class Quotas extends React.Component {
     }
   }
 
+  get omitKeys() {
+    const supportGpu = globals.config.supportGpuType
+    const omitArr = [...resourceLimitKey]
+    supportGpu.forEach(type =>
+      omitArr.push(`limits.${type}`, `requests.${type}`)
+    )
+    return omitArr
+  }
+
   getItems(props) {
-    const hardValues = omit(get(props.data, 'spec.hard', {}), omitKey)
+    const hardValues = omit(get(props.data, 'spec.hard', {}), this.omitKeys)
     const items = []
 
     forOwn(hardValues, (value, key) => {
@@ -94,7 +95,7 @@ export default class Quotas extends React.Component {
   handleAddQuotaItem = items => {
     this.setState({ items }, () => {
       const specHard = get(this.props.data, 'spec.hard')
-      const limits = pick(specHard, [...resourceLimitKey])
+      const limits = pick(specHard, this.omitKeys)
       const template = {}
       items.forEach(({ module, value }) => {
         if (!isUndefined(module)) {

--- a/src/pages/fedprojects/components/ContainerSetting/index.jsx
+++ b/src/pages/fedprojects/components/ContainerSetting/index.jsx
@@ -17,7 +17,7 @@
  */
 
 import React from 'react'
-import { generateId, resourceLimitKey } from 'utils'
+import { generateId, gpuLimitsArr } from 'utils'
 
 import { PATTERN_NAME } from 'utils/constants'
 
@@ -63,19 +63,7 @@ export default class ContainerSetting extends Base {
   }
 
   getGpuLimit() {
-    const hard = this.workspaceQuota
-    return !isEmpty(omit(hard, resourceLimitKey))
-      ? {
-          type: Object.keys(omit(hard, resourceLimitKey))[0]
-            .split('.')
-            .slice(1)
-            .join('.'),
-          value: Number(Object.values(omit(hard, resourceLimitKey))[0]),
-        }
-      : {
-          type: '',
-          value: '',
-        }
+    return gpuLimitsArr(this.workspaceQuota)
   }
 
   get workspaceLimitProps() {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -30,6 +30,8 @@ import {
   isNumber,
   omit,
   pick,
+  pickBy,
+  endsWith,
   replace,
   merge as _merge,
 } from 'lodash'
@@ -773,14 +775,20 @@ export const resourceLimitKey = [
   'requests.memory',
 ]
 
-export const gpuTypeArr = ['requests.nvidia.com/gpu', 'limits.nvidia.com/gpu']
-
 export const supportGpuType = ['nvidia.com/gpu']
 
 const accessModeMapper = {
   ReadWriteOnce: 'RWO',
   ReadOnlyMany: 'ROX',
   ReadWriteMany: 'RWX',
+}
+
+export const gpuLimitsArr = objData => {
+  const supportGpu = globals.config.supportGpuType
+  const gpusObj = pickBy(objData, (_, key) =>
+    supportGpu.some(type => endsWith(key, type))
+  )
+  return Object.keys(gpusObj).map(key => ({ [key]: gpusObj[key] }))
 }
 
 export const map_accessModes = accessModes =>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This problem is caused by the response data includes other fields such as `count/pods` when we get the project quota

![截屏2021-12-20 18 07 22](https://user-images.githubusercontent.com/33231138/146750148-1f13b1f9-a42e-4892-aa4b-54c35c5b759b.png)


### Which issue(s) this PR fixes:
Fixes ##2861

### Special notes for reviewers:
```
When supported gpu just one type
```
+ `single cluster project`

![截屏2021-12-24 14 09 41](https://user-images.githubusercontent.com/33231138/147323711-e649b5f3-cfac-49fb-8422-35a4680812dc.png)

![截屏2021-12-24 14 14 40](https://user-images.githubusercontent.com/33231138/147323856-b28c7df6-f2c8-4a55-a04b-bc1f916fdadf.png)

+ `multi-cluster project`

![截屏2021-12-24 14 17 45](https://user-images.githubusercontent.com/33231138/147324186-4e72c93e-c4dd-4193-a385-2b610d476c0f.png)

![截屏2021-12-24 14 21 08](https://user-images.githubusercontent.com/33231138/147324312-78bc3ea9-d623-4a69-bd18-fd55056194bb.png)

![截屏2021-12-24 14 23 23](https://user-images.githubusercontent.com/33231138/147324591-733f59ed-68cf-4d83-a140-5f43e3ee735b.png)

```
supported gpu has more type
```
https://user-images.githubusercontent.com/33231138/146679307-e4ba06bb-deea-4a5d-8eb9-5573e7864e74.mov



### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
