### PR TITLE
fix: Update Secrets failed for multi cluster project

### DIFF
--- a/src/actions/secret.js
+++ b/src/actions/secret.js
@@ -87,8 +87,13 @@ export default {
       const modal = Modal.open({
         onOk: data => {
           set(data, 'metadata.resourceVersion', detail.resourceVersion)
+          if (props.isFederated) {
+            set(data, 'apiVersion', store.version)
+            set(data, 'kind', store.secretKind)
+          }
           store.update(detail, data).then(() => {
             Modal.close(modal)
+            Notify.success({ content: t('UPDATE_SUCCESSFUL') })
             success && success()
           })
         },

--- a/src/stores/federated.js
+++ b/src/stores/federated.js
@@ -66,6 +66,14 @@ export default class FederatedStore extends Base {
     return 'apis/scheduling.kubefed.io/v1alpha1'
   }
 
+  get version() {
+    return 'types.kubefed.io/v1beta1'
+  }
+
+  get secretKind() {
+    return `FederatedSecret`
+  }
+
   getPath({ namespace }) {
     let path = ''
     if (namespace) {


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This problem was caused by the response data lost 'kind' and 'apiVersion' fields in multi-cluster projects.

### Which issue(s) this PR fixes:
Fixes ##2854

### Special notes for reviewers:

Before, the put request body lose 'kind' and 'apiVersion' field.
> ![截屏2021-12-20 16 13 09](https://user-images.githubusercontent.com/33231138/146734261-271647ce-6cf4-4bc9-8361-9eb612dfe3ee.png)

At now:
> ![截屏2021-12-20 16 11 10](https://user-images.githubusercontent.com/33231138/146734487-76c5210e-4eeb-45b7-b931-832a99c0feb9.png)

### Does this PR introduced a user-facing change?
```release-note
Update Secrets failed for multi cluster project.
```

### Additional documentation, usage docs, etc.: