### PR TITLE
fix: Update application routes failed for multi-cluster project

### DIFF
--- a/src/actions/router.js
+++ b/src/actions/router.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get } from 'lodash'
+import { get, set } from 'lodash'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
 
@@ -102,6 +102,17 @@ export default {
     on({ store, namespace, detail, success, ...props }) {
       const modal = Modal.open({
         onOk: newObject => {
+          const template = get(newObject, 'spec.template', {})
+          const clusterSet = new Set()
+          Object.values(template.spec).forEach(rules => {
+            rules.forEach(item =>
+              item.clusters.forEach(name => clusterSet.add(name))
+            )
+          })
+          const placementClusters = Array.from(clusterSet).map(cluster => ({
+            name: cluster,
+          }))
+          set(newObject, 'spec.placement.clusters', placementClusters)
           store.update(detail, newObject).then(() => {
             Modal.close(modal)
             Notify.success({ content: t('UPDATE_SUCCESSFUL') })


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

The failed reason is the `spec.placement.cluster` fields should include all clusters are mentioned in the `spec.template.spec` fields, otherwise, the update will fail.

### Which issue(s) this PR fixes:
Fixes ##2855

### Special notes for reviewers:

```
I create a route, includes Rohan and Shire two clusters, it works well.
```

![截屏2021-12-22 10 37 25](https://user-images.githubusercontent.com/33231138/147026540-a368a5b3-7254-44c9-9476-2c6cc5afefef.png)

![截屏2021-12-22 10 37 31](https://user-images.githubusercontent.com/33231138/147026550-e9692d3b-81ce-4861-b2c0-bf91cca2fe71.png)


### Does this PR introduced a user-facing change?
```release-note
Update application routes failed for multi-cluster project
```

### Additional documentation, usage docs, etc.:
