### PR TITLE
fix: Update configMap failed for multi-cluster project

### DIFF
--- a/src/actions/configmap.js
+++ b/src/actions/configmap.js
@@ -87,6 +87,10 @@ export default {
       const modal = Modal.open({
         onOk: data => {
           set(data, 'metadata.resourceVersion', detail.resourceVersion)
+          if (props.isFederated) {
+            set(data, 'apiVersion', store.version)
+            set(data, 'kind', 'FederatedConfigMap')
+          }
           store.update(detail, data).then(() => {
             Modal.close(modal)
             Notify.success({ content: t('UPDATE_SUCCESSFUL') })


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This problem was caused by the response data lost 'kind' and 'apiVersion' fields in multi-cluster projects.

### Which issue(s) this PR fixes:
Fixes ##2854

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
Update configMap failed for multi-cluster project.
```

### Additional documentation, usage docs, etc.:
