### PR TITLE
fix: User-defined resource quota and GPU limit are not displayed in the quotas card for the multi-cluster project

### DIFF
--- a/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/QuotaItem/index.jsx
+++ b/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/QuotaItem/index.jsx
@@ -26,7 +26,12 @@ import { ICON_TYPES } from 'utils/constants'
 
 import styles from './index.scss'
 
-const QuotaItem = ({ name, total, used }) => {
+const transformName = (text = '', type) =>
+  type === 'userDefined' && !text.includes('gpu')
+    ? text
+    : t(text.replace(/[. ]/g, '_').toUpperCase())
+
+const QuotaItem = ({ name, total, used, type }) => {
   let ratio = 0
 
   if (name === 'limits.cpu' || name === 'requests.cpu') {
@@ -48,12 +53,16 @@ const QuotaItem = ({ name, total, used }) => {
   ratio = Math.min(Math.max(ratio, 0), 1)
   const labelName = name.indexOf('gpu') > -1 ? 'gpu' : name
   const labelText = labelName === 'gpu' ? `${labelName}.limit` : labelName
+  const iconType =
+    name.indexOf('gpu') > -1
+      ? ICON_TYPES['gpu']
+      : ICON_TYPES[name] ?? 'resource'
 
   return (
     <div className={styles.quota}>
-      <Icon name={ICON_TYPES[name]} size={40} />
+      <Icon name={iconType} size={40} />
       <div className={styles.item}>
-        <div>{t(labelText.replace(/[. ]/g, '_').toUpperCase())}</div>
+        <div>{transformName(labelText, type)}</div>
         <p>{t('RESOURCE_TYPE_SCAP')}</p>
       </div>
       <div className={styles.item}>

--- a/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/QuotaItem/index.jsx
+++ b/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/QuotaItem/index.jsx
@@ -46,12 +46,14 @@ const QuotaItem = ({ name, total, used }) => {
   }
 
   ratio = Math.min(Math.max(ratio, 0), 1)
+  const labelName = name.indexOf('gpu') > -1 ? 'gpu' : name
+  const labelText = labelName === 'gpu' ? `${labelName}.limit` : labelName
 
   return (
     <div className={styles.quota}>
       <Icon name={ICON_TYPES[name]} size={40} />
       <div className={styles.item}>
-        <div>{t(name.replace('.', '_').toUpperCase())}</div>
+        <div>{t(labelText.replace(/[. ]/g, '_').toUpperCase())}</div>
         <p>{t('RESOURCE_TYPE_SCAP')}</p>
       </div>
       <div className={styles.item}>

--- a/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/index.jsx
+++ b/src/pages/fedprojects/containers/QuotaManage/ResourceQuota/index.jsx
@@ -66,7 +66,19 @@ export default class ResourceQuota extends React.Component {
 
   get items() {
     const detail = this.store.data
-    return Object.entries(QUOTAS_MAP)
+    const supportGpuType = globals.config?.supportGpuType ?? []
+    const gpuType = supportGpuType.filter(type =>
+      Object.keys(get(detail, `hard`, {})).some(key => key.endsWith(type))
+    )
+    const mapObj = !gpuType[0]
+      ? QUOTAS_MAP
+      : {
+          ...QUOTAS_MAP,
+          gpu: {
+            name: `requests.${gpuType[0]}`,
+          },
+        }
+    return Object.entries(mapObj)
       .map(([key, value]) => ({
         key,
         name: key,

--- a/src/pages/projects/containers/BaseInfo/ResourceQuota/QuotaItem/index.jsx
+++ b/src/pages/projects/containers/BaseInfo/ResourceQuota/QuotaItem/index.jsx
@@ -88,6 +88,9 @@ const QuotaItem = ({ name, total, used }) => {
     return usedValue
   }
 
+  const transformName = (text = '') =>
+    ICON_TYPES[labelName] ? t(text.replace(/[. ]/g, '_').toUpperCase()) : text
+
   if (name === 'limits.cpu' || name === 'requests.cpu') {
     if (total) {
       ratio = Number(cpuFormat(used)) / Number(cpuFormat(total))
@@ -118,7 +121,7 @@ const QuotaItem = ({ name, total, used }) => {
     <div className={styles.quota}>
       <Icon name={ICON_TYPES[labelName] || 'resource'} size={40} />
       <div className={styles.item}>
-        <div>{t(labelText.replace(/[. ]/g, '_').toUpperCase())}</div>
+        <div>{transformName(labelText)}</div>
         <p>{t('RESOURCE_TYPE_SCAP')}</p>
       </div>
       <div className={styles.item}>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2877,##2798

### Special notes for reviewers:
- No GPU info in the resource card for a multi-cluster project

![截屏2021-12-24 14 04 12](https://user-images.githubusercontent.com/33231138/147323007-8ce50647-36bc-4bf0-b9b9-23bf73557538.png)

- No user-defined resource quota in the resource card
> For user-defined field, all user-defined field fields will not translate their name to another name and will use the same `resource` icon

![截屏2021-12-27 14 46 41](https://user-images.githubusercontent.com/33231138/147443690-57285598-37aa-46be-8e3e-de71eb421cc7.png)
![截屏2021-12-27 14 46 23](https://user-images.githubusercontent.com/33231138/147443692-37997c44-ac3a-4962-bf4c-6f336fb628fa.png)

### Does this PR introduced a user-facing change?
```release-note
User-defined resource quota and GPU limit are not displayed in the quotas card for the multi-cluster project.
```

### Additional documentation, usage docs, etc.:
