### PR TITLE
fix: Add prompt information for button in log search detail page

### DIFF
--- a/src/components/Modals/LogSearch/Logging/Detail/index.jsx
+++ b/src/components/Modals/LogSearch/Logging/Detail/index.jsx
@@ -472,9 +472,11 @@ export default class DetailModal extends React.Component {
 
   renderLink(link, children) {
     return link ? (
-      <a href={link} target="_blank" rel="noopener noreferrer">
-        {children}
-      </a>
+      <Tooltip content={t('VIEW_DETAILS')}>
+        <a href={link} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      </Tooltip>
     ) : (
       children
     )


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2850

### Special notes for reviewers:
```
The tip works when the mouse hover
```

![截屏2021-12-24 16 06 28](https://user-images.githubusercontent.com/33231138/147332861-780fe125-7193-4a7c-abd7-1fb077be55b0.png)

### Does this PR introduced a user-facing change?
```release-note
Add prompt information for button in log search detail page
```

### Additional documentation, usage docs, etc.:
