### PR TITLE
fix: The number of worker nodes is incorrect

### DIFF
--- a/src/stores/node.js
+++ b/src/stores/node.js
@@ -130,7 +130,7 @@ export default class NodeStore extends Base {
 
     const masterWorker = resp.items.filter(
       item =>
-        getNodeRoles(item.metadata.labels).filter(role => role !== 'master')
+        getNodeRoles(item.metadata.labels).every(role => role !== 'master')
           .length > 0
     ).length
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2875

### Special notes for reviewers:

<img width="1188" alt="截屏2021-12-27 17 03 22" src="https://user-images.githubusercontent.com/33231138/147455173-41767b76-9ca6-41cc-bbc8-5f050bde6da2.png">

### Does this PR introduced a user-facing change?
```release-note
The number of worker nodes is incorrect on the cluster nodes page.
```

### Additional documentation, usage docs, etc.:
