### PR TITLE
fix: Cancel gpu field when edit project quota

### DIFF
--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -63,13 +63,6 @@ export default {
         onOk: async data => {
           const hard = get(data, 'spec.hard', {})
 
-          // set gpu parameters into requests and delete extra gpu parameters
-          const gpu = get(data, 'spec.gpu', {})
-          if (!isEmpty(gpu) && gpu.type !== '') {
-            set(data, `spec.hard["requests.${gpu.type}"]`, gpu.value)
-          }
-          data = omit(data, 'spec.gpu')
-
           const params = {
             name: data.name,
             namespace: detail.name,
@@ -105,7 +98,7 @@ export default {
           }
 
           Modal.close(modal)
-
+          Notify.success({ content: t('UPDATE_SUCCESSFUL') })
           success && success()
         },
         detail,

--- a/src/components/Modals/QuotaEdit/index.jsx
+++ b/src/components/Modals/QuotaEdit/index.jsx
@@ -19,16 +19,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { toJS } from 'mobx'
-import {
-  get,
-  set,
-  isEmpty,
-  mergeWith,
-  add,
-  omitBy,
-  endsWith,
-  pickBy,
-} from 'lodash'
+import { get, set, isEmpty, mergeWith, add, omitBy, endsWith } from 'lodash'
 import { Form, Input } from '@kube-design/components'
 import { Modal } from 'components/Base'
 import { ResourceLimit } from 'components/Inputs'
@@ -106,7 +97,7 @@ export default class QuotaEditModal extends React.Component {
     const storeDetail = toJS(this.store.detail)
 
     this.setState({
-      formTemplate: this.cancelGpuSetting(storeDetail),
+      formTemplate: storeDetail,
     })
   }
 
@@ -170,6 +161,18 @@ export default class QuotaEditModal extends React.Component {
         }
       : {}
 
+    // get gpu config form spec.hard field and
+    // pass it to resourceLimit component
+    const supportGpu = globals.config.supportGpuType
+    const hard = get(formTemplate, 'spec.hard', {})
+    const whatTypeGpu = supportGpu.filter(type =>
+      Object.keys(hard).some(key => endsWith(key, type))
+    )
+    const gpuSetting = !isEmpty(whatTypeGpu)
+      ? {
+          [`${whatTypeGpu[0]}`]: hard[`requests.${whatTypeGpu[0]}`],
+        }
+      : {}
     return {
       cpuProps: {
         marks: [
@@ -209,8 +212,8 @@ export default class QuotaEditModal extends React.Component {
         requests: {
           cpu: get(formTemplate, 'spec.hard["requests.cpu"]'),
           memory: get(formTemplate, 'spec.hard["requests.memory"]'),
+          ...gpuSetting,
         },
-        gpu: get(formTemplate, 'spec.gpu'),
       },
       workspaceLimitProps,
       onChange: value => {
@@ -234,40 +237,32 @@ export default class QuotaEditModal extends React.Component {
           'spec.hard["requests.memory"]',
           get(value, 'requests.memory', null)
         )
-        set(formTemplate, `spec.gpu`, get(value, 'gpu'))
+        const supportGpuArr = globals.config.supportGpuType
+        // exclude Gpu fields
+        const oldHard = get(formTemplate, 'spec.hard', {})
+        const noGpuHard = omitBy(oldHard, (_, key) =>
+          supportGpuArr.some(type => key.endsWith(type))
+        )
+        set(formTemplate, 'spec.hard', noGpuHard)
+
+        // set gpu config into hard field
+        const incomeGpu = Object.keys(get(value, 'requests', {})).filter(key =>
+          supportGpuArr.some(type => key.endsWith(type))
+        )
+        if (!isEmpty(incomeGpu)) {
+          const type = incomeGpu[0]
+          set(
+            formTemplate,
+            `spec.hard["requests.${type}"]`,
+            value.requests[`${type}`]
+          )
+        }
       },
       onError: error => {
         this.setState({ error })
       },
       supportGpuSelect: this.props.supportGpuSelect,
     }
-  }
-
-  cancelGpuSetting = formTemplate => {
-    const hard = get(formTemplate, 'spec.hard', {})
-    const supportGpu = globals.config.supportGpuType
-    const filterGpu = omitBy(hard, (_, key) =>
-      supportGpu.some(type => endsWith(key, type))
-    )
-    set(formTemplate, 'spec.hard', filterGpu)
-    if (!isEmpty(hard)) {
-      const gpu = pickBy(hard, (_, key) =>
-        supportGpu.some(type => endsWith(key, type))
-      )
-      if (!isEmpty(gpu)) {
-        const type = Object.keys(gpu)[0].split('.')
-        set(formTemplate, 'spec.gpu', {
-          type: type.slice(1).join('.'),
-          value: Object.values(gpu)[0],
-        })
-      }
-    } else {
-      set(formTemplate, 'spec.gpu', {
-        type: '',
-        value: '',
-      })
-    }
-    return formTemplate
   }
 
   render() {

--- a/src/stores/federated.js
+++ b/src/stores/federated.js
@@ -18,7 +18,7 @@
 
 import { set, get, keyBy, findKey, cloneDeep } from 'lodash'
 import { action, observable } from 'mobx'
-import { withDryRun, getGpuFromRes } from 'utils'
+import { withDryRun, LimitsEqualRequests } from 'utils'
 import ObjectMapper from 'utils/object.mapper'
 import { MODULE_KIND_MAP } from 'utils/constants'
 
@@ -223,7 +223,7 @@ export default class FederatedStore extends Base {
       ...ObjectMapper.federated(this.mapper)(item),
     }))
 
-    getGpuFromRes(data)
+    LimitsEqualRequests(data)
 
     this.list.update({
       data,

--- a/src/stores/limitrange.js
+++ b/src/stores/limitrange.js
@@ -18,7 +18,7 @@
 
 import Base from 'stores/base'
 import { action } from 'mobx'
-import { getGpuFromRes } from 'utils'
+import { LimitsEqualRequests } from 'utils'
 
 export default class LimitRangeStore extends Base {
   module = 'limitranges'
@@ -43,7 +43,7 @@ export default class LimitRangeStore extends Base {
       ...this.mapper(item),
     }))
 
-    getGpuFromRes(data)
+    LimitsEqualRequests(data)
 
     this.list.update({
       data,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -699,7 +699,7 @@ export const omitJobGpuLimit = (data, path) => {
   }
 }
 
-export const getGpuFromRes = data => {
+export const LimitsEqualRequests = data => {
   if (data.length > 0) {
     const limits = get(data, '[0].limit.default', {})
     const requests = get(data, '[0].limit.defaultRequest', {})
@@ -710,23 +710,6 @@ export const getGpuFromRes = data => {
     }
     if (limitItem('memory') === reqItem('memory')) {
       set(data[0].limit, 'defaultRequest.memory', undefined)
-    }
-    const gpu = isEmpty(limits) ? {} : omit(limits, ['cpu', 'memory'])
-    const gpuKey = Object.keys(gpu)[0]
-    if (isEmpty(gpu)) {
-      set(data[0].limit, 'gpu', {
-        type: supportGpuType[0],
-        value: '',
-      })
-    } else {
-      data[0] = omit(data[0], [
-        `limit.default['${gpuKey}']`,
-        `limit.defaultRequest['${gpuKey}']`,
-      ])
-      set(data[0].limit, 'gpu', {
-        type: gpuKey,
-        value: Object.values(gpu)[0],
-      })
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This is part of the work about #2870. In order to avoid adding the GPU field into the yaml, we need to get GPU info from the requests field and save the GPU limit into the requests and limits field in the ResourceLimit component, so some operations about the GPU are no longer needed.

### Which issue(s) this PR fixes:
Fixes ##2870

### Special notes for reviewers:
```
No UI change
```
![截屏2021-12-27 17 36 32](https://user-images.githubusercontent.com/33231138/147458420-b8571470-d517-4af4-a344-7d65dbeba3d6.png)

![截屏2021-12-27 17 38 14](https://user-images.githubusercontent.com/33231138/147458429-fcedaea0-d53c-4482-9e3f-e9c492aa72bd.png)


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
