### PR TITLE
fix: Delete gpu field when editing project default resource

### DIFF
--- a/src/actions/project.js
+++ b/src/actions/project.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, set, omitBy, isEmpty, omit } from 'lodash'
+import { get, set, omitBy, isEmpty } from 'lodash'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
 import QuotaEditModal from 'components/Modals/QuotaEdit'
@@ -122,19 +122,6 @@ export default {
     }) {
       const modal = Modal.open({
         onOk: async data => {
-          const gpu = get(data, 'gpu', {})
-          data = omit(data, 'gpu')
-          detail = omit(detail, 'limit.gpu')
-
-          // if requests and limits is unsetted, they will be undefined
-          // for set gpu params, it should be an object
-          if (isEmpty(data.default) && isEmpty(data.defaultRequest)) {
-            data = { ...data, default: {}, defaultRequest: {} }
-          }
-          if (!isEmpty(gpu) && gpu.type !== '' && gpu.value !== '') {
-            set(data, `default["${gpu.type}"]`, Number(gpu.value))
-          }
-
           // deal with the case that input number as 4.
           const { limits, requests } = limits_Request_EndsWith_Dot({
             limits: data.default,

--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -451,8 +451,13 @@ export default class ResourceLimit extends React.Component {
     }
 
     // pass gpu input config into limits and requests field
-    set(result, 'limits', { ...result.limits, [`${gpu.type}`]: gpu.value })
-    set(result, 'requests', { ...result.requests, [`${gpu.type}`]: gpu.value })
+    if (!!gpu.type && !!gpu.value) {
+      set(result, 'limits', { ...result.limits, [`${gpu.type}`]: gpu.value })
+      set(result, 'requests', {
+        ...result.requests,
+        [`${gpu.type}`]: gpu.value,
+      })
+    }
 
     onChange(result)
   }

--- a/src/pages/fedprojects/containers/BaseInfo/DefaultResource/index.jsx
+++ b/src/pages/fedprojects/containers/BaseInfo/DefaultResource/index.jsx
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get } from 'lodash'
+import { get, endsWith, isEmpty } from 'lodash'
 import React from 'react'
 
 import { Icon } from '@kube-design/components'
@@ -36,6 +36,15 @@ class DefaultResource extends React.Component {
     const memoryRequest = memoryFormat(
       get(detail, 'limit.defaultRequest.memory')
     )
+    // get GPU config from the supported type
+    const supportGpu = globals.config.supportGpuType
+    const defaultRequest = get(detail, 'limit.defaultRequest', {})
+    const gpuType = supportGpu.filter(type =>
+      Object.keys(defaultRequest).some(key => endsWith(key, type))
+    )
+    const gpu = isEmpty(gpuType)
+      ? {}
+      : { value: defaultRequest[`${gpuType[0]}`], type: gpuType }
 
     return (
       <Panel title={t('DEFAULT_CONTAINER_QUOTA_PL')}>
@@ -66,6 +75,17 @@ class DefaultResource extends React.Component {
                 {memoryLimit ? `${memoryLimit} Mi` : t('NO_LIMIT_TCAP')}
               </div>
               <p>{t('MEMORY_LIMIT_SCAP')}</p>
+            </div>
+          </div>
+          <div className={styles.contentItem}>
+            <img src="/assets/GPU.svg" size={48} />
+            <div className={styles.item}>
+              <div>{gpu.value ? gpu.type : t('NONE')}</div>
+              <p>{t('GPU_TYPE_SCAP')}</p>
+            </div>
+            <div className={styles.item}>
+              <div>{gpu.value ? gpu.value : t('NO_LIMIT_TCAP')}</div>
+              <p>{t('GPU_LIMIT_SCAP')}</p>
             </div>
           </div>
         </div>

--- a/src/pages/fedprojects/containers/BaseInfo/DefaultResource/index.scss
+++ b/src/pages/fedprojects/containers/BaseInfo/DefaultResource/index.scss
@@ -2,8 +2,8 @@
 @import '~scss/mixins';
 
 .item {
-  min-width: 160px;
   margin-left: 12px;
+  flex: 1;
 
   & > div {
     @include TypographyTitleH6($dark-color07);
@@ -18,8 +18,10 @@
   display: flex;
   justify-content: flex-start;
   padding: 8px 12px;
+  overflow: auto;
 }
 
 .contentItem {
   display: flex;
+  flex: 1;
 }

--- a/src/pages/projects/components/Modals/DefaultResourceEdit/index.jsx
+++ b/src/pages/projects/components/Modals/DefaultResourceEdit/index.jsx
@@ -82,10 +82,6 @@ export default class DefaultResourceEditModal extends React.Component {
     return {
       requests: get(this.props.detail, 'limit.defaultRequest', {}),
       limits: get(this.props.detail, 'limit.default', {}),
-      gpu: get(this.props.detail, 'limit.gpu', {
-        type: '',
-        value: '',
-      }),
     }
   }
 
@@ -94,7 +90,6 @@ export default class DefaultResourceEditModal extends React.Component {
       data: {
         default: data.limits,
         defaultRequest: data.requests,
-        gpu: data.gpu,
       },
     })
   }

--- a/src/pages/projects/containers/BaseInfo/DefaultResource/index.jsx
+++ b/src/pages/projects/containers/BaseInfo/DefaultResource/index.jsx
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get } from 'lodash'
+import { get, endsWith, isEmpty } from 'lodash'
 import React from 'react'
 
 import { Icon } from '@kube-design/components'
@@ -36,7 +36,15 @@ class DefaultResource extends React.Component {
     const memoryRequest = memoryFormat(
       get(detail, 'limit.defaultRequest.memory')
     )
-    const gpu = get(detail, 'limit.gpu', {})
+    // get GPU config from the supported type
+    const supportGpu = globals.config.supportGpuType
+    const defaultRequest = get(detail, 'limit.defaultRequest', {})
+    const gpuType = supportGpu.filter(type =>
+      Object.keys(defaultRequest).some(key => endsWith(key, type))
+    )
+    const gpu = isEmpty(gpuType)
+      ? {}
+      : { value: defaultRequest[`${gpuType[0]}`], type: gpuType }
 
     return (
       <Panel title={t('DEFAULT_CONTAINER_QUOTA_PL')}>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

- This part of the job of #2870
- Add GPU limit info in the default container quotas card in the multi-cluster project.

### Which issue(s) this PR fixes:
Fixes ##2870


### Special notes for reviewers:

- Add GPU limit info 
![截屏2021-12-27 18 09 58](https://user-images.githubusercontent.com/33231138/147461516-de06b32e-d5ae-4f5d-9bfc-25e57ccd1888.png)

- delete GPU field
![截屏2021-12-29 10 50 11](https://user-images.githubusercontent.com/33231138/147622907-edc49c30-593f-4bdc-95eb-37dd9feb8d0d.png)

### Does this PR introduced a user-facing change?
```release-note
Add GPU limit info in the default container quotas card in the multi-cluster project.
```

### Additional documentation, usage docs, etc.:

This one should be merged after #2878, and it will need to resolve conflicts.