### PR TITLE
fix: The quantity unit of the container group quota is incorrect

### DIFF
--- a/src/components/Modals/QuotaEdit/Quotas/Item.jsx
+++ b/src/components/Modals/QuotaEdit/Quotas/Item.jsx
@@ -58,7 +58,10 @@ export default class QuotaItem extends React.Component {
   renderInputByModule = () => {
     const { value } = this.props
     const mapKey = Object.keys(QUOTAS_MAP)
-    if (mapKey.includes(value.module)) {
+    const itemName = Object.entries(QUOTAS_MAP)
+      .filter(item => item[0] !== value.module)
+      .map(item => item[1].name)
+    if (mapKey.concat(itemName).includes(value.module)) {
       return (
         <NumberInput
           name="value"


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug
### What this PR does / why we need it:

Before, when users edit project resource quotas, if they set the key as counts/pods, so the value of limit can be set as '20G' and override the pods' limits., it is incorrect.

![截屏2021-12-29 09 48 16](https://user-images.githubusercontent.com/33231138/147620665-eaa59f02-e4d3-45d9-943b-ddc296651319.png)

![截屏2021-12-29 09 48 25](https://user-images.githubusercontent.com/33231138/147620666-409c22b2-3e88-435f-b5e3-30e282b1430c.png)

### Which issue(s) this PR fixes:
Fixes ##2797

### Special notes for reviewers:

![截屏2021-12-29 10 11 59](https://user-images.githubusercontent.com/33231138/147620963-8faef95b-08a6-4eeb-a066-4b9fd5ba008d.png)

### Does this PR introduced a user-facing change?
```release-note
The unit of project resource quotas limit is incorrect.
```

### Additional documentation, usage docs, etc.:
Now, if users set the key as one of the follows, the value only can be an integer:
- `limits.cpu`
- `requests.cpu`
-  `limits.memory`
- `requests.memory`
- `count/pods` or `pods`
- `count/deployments.apps` or `deployments`
- `count/statefulsets.apps` or `statefulsets`
- `count/daemonsets.apps` or  `daemonsets`
- `count/jobs.batch` or `jobs`
- `count/cronjobs.batch` or `cronjobs`
- `persistentvolumeclaims`
- `count/services` or `services`
- `count/ingresses.extensions` or `routes`
- `count/secrets` or `secrets`
- `count/configmaps` or `configmaps`

For other keys, it will not restrict the type of input value.