### PR TITLE
fix: Yaml content is not matched with the monitoring template type

### DIFF
--- a/src/components/Forms/Dashboard/BaseInfo/index.jsx
+++ b/src/components/Forms/Dashboard/BaseInfo/index.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react'
 import { observer } from 'mobx-react'
-import { get, set, isEmpty } from 'lodash'
+import { get, set, isEmpty, cloneDeep } from 'lodash'
 import { Column, Columns, Form, Input, TextArea } from '@kube-design/components'
 import CardSelect from 'components/Inputs/CardSelect'
 import { PATTERN_NAME, MODULE_KIND_MAP } from 'utils/constants'
@@ -33,7 +33,7 @@ export default class BaseInfo extends React.Component {
 
     if (isEmpty(this.formTemplate.spec)) {
       const defaultKey = Object.keys(templateSettings)[0]
-      const defaultValue = templateSettings[defaultKey].settings
+      const defaultValue = cloneDeep(templateSettings[defaultKey].settings)
       set(this.formTemplate, 'spec', defaultValue)
     }
   }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

the YAML content is not matched with the monitoring template type after creating a dashboard.

### Which issue(s) this PR fixes:
Fixes ##2848

### Special notes for reviewers:
```
No UI problem
```

### Does this PR introduced a user-facing change?
```release-note
Yaml content is not matched with the monitoring template type after creating a dashboard.
```

### Additional documentation, usage docs, etc.:

This problem is caused by the template.json being referenced by the page data, its 'settings. title' field will be overridden with the monitoring template type.