### PR TITLE
fix: The replicas count is covered by the operation button when creating a composing Application in the multi-cluster project

### DIFF
--- a/src/pages/projects/components/Modals/CreateApp/Services/ServiceList/index.scss
+++ b/src/pages/projects/components/Modals/CreateApp/Services/ServiceList/index.scss
@@ -18,9 +18,14 @@
   &:hover {
     border-color: $border-hover-color;
     box-shadow: 0 4px 8px 0 rgba(36, 46, 66, 0.2);
+    cursor: pointer;
 
     :global .buttons {
       display: block;
+    }
+
+    .clusters {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

The replicas count will hide when the user hovers the service.

### Which issue(s) this PR fixes:
Fixes ##2776

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/147638233-99b24b0a-a88a-43fa-b4ef-3b17851edeb1.mov

### Does this PR introduced a user-facing change?
```release-note
The replicas count is covered by the operation button when creating a composing Application in the multi-cluster project.
```

### Additional documentation, usage docs, etc.:
