### PR TITLE
fix: Pipeline start time invalid

### DIFF
--- a/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
@@ -298,7 +298,8 @@ export default class Activity extends React.Component {
       title: t('UPDATE_TIME_TCAP'),
       dataIndex: 'startTime',
       width: '20%',
-      render: time => getLocalTime(time).format('YYYY-MM-DD HH:mm:ss'),
+      render: time =>
+        time ? getLocalTime(time).format('YYYY-MM-DD HH:mm:ss') : '-',
     },
     {
       isHideable: false,


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2732

### Special notes for reviewers:

If the pipeline record doesn't have the start time, the start time will be '-'.

![截屏2021-12-29 16 39 31](https://user-images.githubusercontent.com/33231138/147643436-adc04989-11a8-4e46-ae9c-0cad4aeda5c5.png)

### Does this PR introduced a user-facing change?
```release-note
The update time of pipeline is displayed as 'Invalid date'.
```

### Additional documentation, usage docs, etc.:
