### PR TITLE
fix: Can't enter PV detail page in member cluster

### DIFF
--- a/src/stores/pv.js
+++ b/src/stores/pv.js
@@ -25,7 +25,8 @@ export default class PvcStore extends Base {
   getDetailUrl = (params = {}) =>
     `${this.getResourceUrl(params)}/${params.name}`
 
-  getKs8Url = (params = {}) => `api/v1/${this.module}/${params.name}`
+  getKs8Url = (params = {}) =>
+    `api/v1${this.getPath(params)}/${this.module}/${params.name}`
 
   @action
   async fetchDetail(params) {


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

The problem is caused by the request URL lost cluster field.

### Which issue(s) this PR fixes:
Fixes ##2891

### Special notes for reviewers:

Rohan cluster is a member cluster

https://user-images.githubusercontent.com/33231138/148345432-e90ccd66-edc8-4edf-bac1-a0ee4380e79b.mov

### Does this PR introduced a user-facing change?
```release-note
Can't enter PV detail page in member cluster
```

### Additional documentation, usage docs, etc.:

