### PR TITLE
fix: Delete gpu field when creating workload

### DIFF
--- a/src/actions/application.js
+++ b/src/actions/application.js
@@ -19,13 +19,9 @@
 import { get, set, isEmpty, omit } from 'lodash'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
-import { mergeLabels, updateFederatedAnnotations, omitJobGpuLimit } from 'utils'
+import { mergeLabels, updateFederatedAnnotations } from 'utils'
 import FORM_TEMPLATES from 'utils/form.templates'
-import {
-  MODULE_KIND_MAP,
-  MAPPER_GPU_SPEC_PATH,
-  OMIT_TOTAL_REPLICAS,
-} from 'utils/constants'
+import { MODULE_KIND_MAP, OMIT_TOTAL_REPLICAS } from 'utils/constants'
 
 import ROUTER_FORM_STEPS from 'configs/steps/ingresses'
 
@@ -57,14 +53,6 @@ export default {
         onOk: data => {
           const deployments = omit(data, ['application', 'ingress'])
           Object.keys(deployments).forEach(name => {
-            omitJobGpuLimit(
-              data,
-              `${name}.${MAPPER_GPU_SPEC_PATH.app_deployment}`
-            )
-            omitJobGpuLimit(
-              data,
-              `${name}.${MAPPER_GPU_SPEC_PATH.app_workload}`
-            )
             data = omit(data, OMIT_TOTAL_REPLICAS(name))
           })
           store.create(data, { cluster, namespace }).then(() => {

--- a/src/actions/federated.js
+++ b/src/actions/federated.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, set, unset, cloneDeep, uniqBy, isEmpty, omit } from 'lodash'
+import { get, set, unset, cloneDeep, uniqBy, isEmpty } from 'lodash'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
 import FedProjectCreateModal from 'components/Modals/FedProjectCreate'
@@ -26,7 +26,7 @@ import FedProjectAddClusterModal from 'workspaces/components/Modals/FedProjectAd
 import DeleteModal from 'components/Modals/Delete'
 import FORM_TEMPLATES from 'utils/form.templates'
 import FED_TEMPLATES from 'utils/fed.templates'
-import { multiCluster_overrides_gpu } from 'utils'
+import { multiCluster_overrides_Dot } from 'utils'
 
 import FederatedStore from 'stores/federated'
 import ProjectStore from 'stores/project'
@@ -135,22 +135,8 @@ export default {
     on({ store, detail, success, module, supportGpuSelect = false, ...props }) {
       const modal = Modal.open({
         onOk: data => {
-          const containers = get(
-            data,
-            'spec.template.spec.template.spec.containers',
-            []
-          )
-          const newContainers = containers.map(item =>
-            omit(item, 'resources.gpu')
-          )
-          set(
-            data,
-            'spec.template.spec.template.spec.containers',
-            newContainers
-          )
-
           const overrides = get(data, 'spec.overrides', [])
-          multiCluster_overrides_gpu(overrides)
+          multiCluster_overrides_Dot(overrides)
 
           const customMode = get(data, 'spec.template.spec.customMode', {})
           if (!isEmpty(customMode)) {

--- a/src/actions/workload.js
+++ b/src/actions/workload.js
@@ -18,7 +18,7 @@
 
 import { get, isEmpty, omit } from 'lodash'
 import { toJS } from 'mobx'
-import { withProps, omitJobGpuLimit, multiCluster_overrides_gpu } from 'utils'
+import { withProps, multiCluster_overrides_Dot } from 'utils'
 import { Notify } from '@kube-design/components'
 import { Modal } from 'components/Base'
 
@@ -30,11 +30,7 @@ import EditConfigTemplateModal from 'projects/components/Modals/ConfigTemplate'
 import EditServiceModal from 'projects/components/Modals/ServiceSetting/StatefulSet'
 import ClusterDiffSettings from 'components/Forms/Workload/ClusterDiffSettings'
 import DeleteModal from 'projects/components/Modals/WorkloadDelete'
-import {
-  MODULE_KIND_MAP,
-  MAPPER_GPU_SPEC_PATH,
-  OMIT_TOTAL_REPLICAS,
-} from 'utils/constants'
+import { MODULE_KIND_MAP, OMIT_TOTAL_REPLICAS } from 'utils/constants'
 import FORM_TEMPLATES from 'utils/form.templates'
 import formPersist from 'utils/form.persist'
 import DEPLOYMENTS_FORM_STEPS from 'configs/steps/deployments'
@@ -120,23 +116,15 @@ export default {
       const modal = Modal.open({
         onOk: newObject => {
           if (isFederated) {
-            MAPPER_GPU_SPEC_PATH[kind] &&
-              omitJobGpuLimit(
-                newObject[kind],
-                MAPPER_GPU_SPEC_PATH[`Federate_${kind}`]
-              )
             if (module === 'deployments') {
-              multiCluster_overrides_gpu(
+              multiCluster_overrides_Dot(
                 get(newObject, 'Deployment.spec.overrides', [])
               )
             } else if (module === 'statefulsets') {
-              multiCluster_overrides_gpu(
+              multiCluster_overrides_Dot(
                 get(newObject, 'StatefulSet.spec.overrides', [])
               )
             }
-          } else {
-            MAPPER_GPU_SPEC_PATH[kind] &&
-              omitJobGpuLimit(newObject[kind], MAPPER_GPU_SPEC_PATH[kind])
           }
           newObject = omit(newObject, OMIT_TOTAL_REPLICAS(kind))
           let data = newObject
@@ -273,7 +261,6 @@ export default {
     on({ store, detail, success, supportGpuSelect = false, ...props }) {
       const modal = Modal.open({
         onOk: data => {
-          omitJobGpuLimit(data, 'spec.template.spec.containers')
           const customMode = get(data, 'spec.template.spec.customMode', {})
 
           if (!isEmpty(customMode)) {

--- a/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
@@ -48,7 +48,6 @@ export default class ContainerSetting extends React.Component {
     return {
       requests: limitRange.defaultRequest || {},
       limits: limitRange.default || {},
-      gpu: limitRange.gpu || {},
     }
   }
 

--- a/src/components/Forms/Workload/ContainerSettings/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/index.jsx
@@ -33,7 +33,7 @@ import {
   endsWith,
 } from 'lodash'
 import React from 'react'
-import { generateId, getContainerGpu, resourceLimitKey } from 'utils'
+import { generateId, cancelContainerDot, resourceLimitKey } from 'utils'
 import { MODULE_KIND_MAP } from 'utils/constants'
 import { getLeftQuota } from 'utils/workload'
 
@@ -518,11 +518,11 @@ export default class ContainerSetting extends React.Component {
     })
 
     _initContainers.forEach(item => {
-      getContainerGpu(item)
+      cancelContainerDot(item)
     })
 
     _containers.forEach(item => {
-      getContainerGpu(item)
+      cancelContainerDot(item)
     })
 
     set(this.fedFormTemplate, `${this.prefix}spec.containers`, _containers)

--- a/src/pages/fedprojects/components/ContainerSetting/index.jsx
+++ b/src/pages/fedprojects/components/ContainerSetting/index.jsx
@@ -29,7 +29,7 @@ import {
   Columns,
   Column,
 } from '@kube-design/components'
-import { omit, isEmpty, get } from 'lodash'
+import { isEmpty, get } from 'lodash'
 import { ResourceLimit } from 'components/Inputs'
 import ToggleView from 'components/ToggleView'
 
@@ -39,26 +39,14 @@ import styles from './index.scss'
 export default class ContainerSetting extends Base {
   get defaultResourceLimit() {
     const { limitRanges = {} } = this.props
-    const gpu = {
-      type: '',
-      value: '',
-    }
 
     if (!limitRanges.limits && !limitRanges.requests) {
       return undefined
     }
 
-    const gpuInfo = omit(limitRanges.requests, ['cpu', 'memory'])
-
-    if (!isEmpty(gpuInfo)) {
-      gpu.type = Object.keys(gpuInfo)[0]
-      gpu.value = Object.values(gpuInfo)[0]
-    }
-
     return {
       requests: limitRanges.requests || {},
       limits: limitRanges.limits || {},
-      gpu,
     }
   }
 

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1111,17 +1111,6 @@ export const NODE_ROLE_TAG_TYPE = {
   worker: 'default',
 }
 
-export const MAPPER_GPU_SPEC_PATH = {
-  Deployment: 'spec.template.spec.containers',
-  StatefulSet: 'spec.template.spec.containers',
-  Job: 'spec.template.spec.containers',
-  CronJob: 'spec.jobTemplate.spec.template.spec.containers',
-  Federate_Deployment: 'spec.template.spec.template.spec.containers',
-  Federate_StatefulSet: 'spec.template.spec.template.spec.containers',
-  app_deployment: 'Deployment.spec.template.spec.containers',
-  app_workload: 'workload.spec.template.spec.containers',
-}
-
 export const OMIT_TOTAL_REPLICAS = kind => [
   `${kind}.spec.template.totalReplicas`,
   'totalReplicas',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

- This part of the job of #2870

- There is no need to deal with GPU field anymore, so delete redundant operations.

### Which issue(s) this PR fixes:
Fixes ##2870

### Special notes for reviewers:
```
Create a deployment, and then switch to edit YAML mode
```
![截屏2022-01-06 17 01 30](https://user-images.githubusercontent.com/33231138/148357458-aaef1d6e-2801-43cc-b0b8-4e310d144c6c.png)


### Does this PR introduced a user-facing change?

```release-note
Use kubectl to apply the YAML which is copied from the deployments detail page failed.
```

### Additional documentation, usage docs, etc.:
