### PR TITLE
fix: Invalid API request of listing s2ibuildertemplates in multi-cluster environment

### DIFF
--- a/src/components/Forms/ImageBuilder/B2IForm/index.jsx
+++ b/src/components/Forms/ImageBuilder/B2IForm/index.jsx
@@ -106,7 +106,9 @@ export default class S2IForm extends React.Component {
 
   getTemplateList = async () => {
     this.setState({ isGetTemplateListLoading: true })
-    const lists = await this.builderStore.getBuilderTemplate()
+    const lists = await this.builderStore.getBuilderTemplate({
+      cluster: this.props.cluster,
+    })
     this.setState({
       builderTemplateLists: get(lists, 'items', []),
       isGetTemplateListLoading: false,


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##2886

### Special notes for reviewers:

The workspace `Test-url`  includes cluster host and cluster member. 
The project `hellos` is a single cluster project in workspace `Test-url`,  located in the member cluster.

![截屏2022-01-10 16 56 34](https://user-images.githubusercontent.com/33231138/148739958-c56b9592-2651-4798-9fdd-b4f37d557dea.png)

### Does this PR introduced a user-facing change?
```release-note
Invalid API request of listing s2ibuilder templates in the multi-cluster environment
```

### Additional documentation, usage docs, etc.:
