### PR TITLE
fix: Webhook token and auth should be required fields

### DIFF
--- a/locales/en/l10n-platformSettings-notificationManagement-notificationConfiguration.js
+++ b/locales/en/l10n-platformSettings-notificationManagement-notificationConfiguration.js
@@ -175,4 +175,7 @@ module.exports = {
   NO_AUTH: 'No authentication',
   BEARER_TOKEN: 'Bearer token',
   TOKEN: 'Token',
+  WEBHOOK_USERNAME_EMPTY_DESC: 'Please enter a username.',
+  WEBHOOK_PASSWORD_EMPTY_DESC: 'Please enter a password.',
+  WEBHOOK_TOKEN_EMPTY_DESC: 'Please enter a token.',
 }

--- a/src/components/Forms/Notification/WebhookForm/index.jsx
+++ b/src/components/Forms/Notification/WebhookForm/index.jsx
@@ -96,10 +96,20 @@ export default class WebhookForm extends Component {
           </Form.Item>
           {type === 'basic' && (
             <>
-              <Form.Item label={t('USERNAME')}>
+              <Form.Item
+                label={t('USERNAME')}
+                rules={[
+                  { required: true, message: t('WEBHOOK_USERNAME_EMPTY_DESC') },
+                ]}
+              >
                 <Input name="receiver.spec.webhook.httpConfig.basicAuth.username" />
               </Form.Item>
-              <Form.Item label={t('PASSWORD')}>
+              <Form.Item
+                label={t('PASSWORD')}
+                rules={[
+                  { required: true, message: t('WEBHOOK_PASSWORD_EMPTY_DESC') },
+                ]}
+              >
                 <InputPassword
                   name="secret.data.password"
                   type="password"
@@ -110,7 +120,12 @@ export default class WebhookForm extends Component {
           )}
           {type === 'token' && (
             <>
-              <Form.Item label={t('TOKEN')}>
+              <Form.Item
+                label={t('TOKEN')}
+                rules={[
+                  { required: true, message: t('WEBHOOK_TOKEN_EMPTY_DESC') },
+                ]}
+              >
                 <Input name="secret.data.token" />
               </Form.Item>
             </>


### PR DESCRIPTION
Signed-off-by: xuliwenwenwen <liwenxu@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[kubesphere/kubesphere#4310](https://github.com/kubesphere/kubesphere/issues/4310)

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Webhook token and auth should be required fields.
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
