### PR TITLE
fix: Verify devops project name input

### DIFF
--- a/src/components/Modals/DevOpsCreate/index.jsx
+++ b/src/components/Modals/DevOpsCreate/index.jsx
@@ -133,12 +133,14 @@ export default class ProjectCreateModal extends React.Component {
     const { formTemplate, workspace } = this.props
     const cluster = get(formTemplate, 'spec.placement.cluster')
 
-    this.store.checkName({ name: value, cluster, workspace }).then(resp => {
-      if (resp.exist) {
-        return callback({ message: t('NAME_EXIST_DESC'), field: rule.field })
-      }
-      callback()
-    })
+    this.store
+      .checkName({ name: value, cluster, workspace }, { generateName: true })
+      .then(resp => {
+        if (resp.exist) {
+          return callback({ message: t('NAME_EXIST_DESC'), field: rule.field })
+        }
+        callback()
+      })
   }
 
   handleClusterChange = () => {

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -246,10 +246,10 @@ export default class BaseStore {
   }
 
   @action
-  checkName(params) {
+  checkName(params, query) {
     return request.get(
       this.getDetailUrl(params),
-      {},
+      { ...query },
       {
         headers: { 'x-check-exist': true },
       }


### PR DESCRIPTION
Signed-off-by: mango <xu.weiKyrie@foxmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/area devops


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #2707

### Special notes for reviewers:
```
```
The screentshot like below:
![image](https://user-images.githubusercontent.com/35127166/149064229-02ed405f-140a-4cce-98bd-049553d9df73.png)



### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

