### PR TITLE
 fix: Block users from going to the next step when the metadata validation fails

### DIFF
--- a/src/components/Forms/Workload/ContainerSettings/Metadata/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/Metadata/index.jsx
@@ -20,16 +20,34 @@ import React from 'react'
 import { Form } from '@kube-design/components'
 import { PropertiesInput } from 'components/Inputs'
 
-export default function Metadata() {
-  return (
-    <>
-      <Form.Item label={t('ANNOTATION_PL')}>
-        <PropertiesInput
-          name="spec.template.metadata.annotations"
-          addText={t('ADD')}
-          hiddenKeys={globals.config.preservedAnnotations}
-        />
-      </Form.Item>
-    </>
-  )
+export default class Metadata extends React.Component {
+  metaError = ''
+
+  handleMetaError = (err = '') => {
+    this.metaError = err
+  }
+
+  metaDataValidator = (rule, value, callback) => {
+    if (this.metaError === '') {
+      callback()
+    }
+  }
+
+  render() {
+    return (
+      <>
+        <Form.Item
+          label={t('ANNOTATION_PL')}
+          rules={[{ validator: this.metaDataValidator }]}
+        >
+          <PropertiesInput
+            name="spec.template.metadata.annotations"
+            addText={t('ADD')}
+            hiddenKeys={globals.config.preservedAnnotations}
+            onError={this.handleMetaError}
+          />
+        </Form.Item>
+      </>
+    )
+  }
 }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

During creating a workload, if the user sets metadata for the container and validates failure, the user can't save it and enter the next step. Until then, we did not limit it.

### Which issue(s) this PR fixes:
Part of the work of  ##2431

### Special notes for reviewers:

![截屏2022-01-12 17 26 58](https://user-images.githubusercontent.com/33231138/149105462-ef862275-c55a-4ccb-bf20-820863819fcb.png)


https://user-images.githubusercontent.com/33231138/149309979-f2bb3df6-972e-47d7-86e9-c004a9a4e0ae.mov

### Does this PR introduced a user-facing change?
```release-note
Block users from going to the next step when the metadata validation fails
```

### Additional documentation, usage docs, etc.:
