### PR TITLE
fix: User can't edit resource limit for workload during create deloyment

### DIFF
--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -200,7 +200,8 @@ export default class ResourceLimit extends React.Component {
         value: '',
       }
     }
-    const types = Object.keys(value.requests).filter(key =>
+    // The value may not have requests field
+    const types = Object.keys(get(value, 'requests', {})).filter(key =>
       supportGpuType.some(item => key.endsWith(item))
     )
     const type = !isEmpty(types) ? types[0] : supportGpuType[0]


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

During creating a deployment, if the user creates a container without a requests limit, and then he wants to edit it again, the edit page will be broken.

`Note`: it does not affect programs that have already been released.

`How to reproduce`:

https://user-images.githubusercontent.com/33231138/149311872-1afd20f2-429f-4288-88ad-065bed2f493e.mov

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```