### PR TITLE
fix: Fix The TCP traffic data in traffic monitoring is empty

### DIFF
--- a/src/components/Graph/Detail/Monitors/ServiceMonitor.jsx
+++ b/src/components/Graph/Detail/Monitors/ServiceMonitor.jsx
@@ -68,12 +68,9 @@ export default class Monitors extends React.Component {
   }
 
   getData() {
-    const { detail, store, protocol } = this.props
+    const { detail, store } = this.props
 
-    const func =
-      protocol === 'tcp'
-        ? this.store.fetchAppMetrics.bind(this.store)
-        : this.store.fetchServiceMetrics.bind(this.store)
+    const func = this.store.fetchServiceMetrics.bind(this.store)
 
     if (detail && detail.name) {
       func(
@@ -138,34 +135,8 @@ export default class Monitors extends React.Component {
     }
 
     const { metrics } = this.state
-    const received = get(metrics, 'metrics.tcp_received.matrix[0].values', [])
-    const sent = get(metrics, 'metrics.tcp_sent.matrix[0].values', [])
-
-    if (received.length === 0 && sent.length === 0) {
-      return {}
-    }
-
-    return getAreaChartOps({
-      title: 'bandwith',
-      legend: ['Send', 'Receive'],
-      data: [{ values: sent }, { values: received }],
-      unit: 'B/s',
-    })
-  }
-
-  get tcpOutMetrics() {
-    const { detail } = this.props
-    if (!detail) {
-      return {}
-    }
-
-    const { outMetrics } = this.state
-    const received = get(
-      outMetrics,
-      'metrics.tcp_received.matrix[0].values',
-      []
-    )
-    const sent = get(outMetrics, 'metrics.tcp_sent.matrix[0].values', [])
+    const received = get(metrics, 'tcp_received[0].datapoints', [])
+    const sent = get(metrics, 'tcp_sent[0].datapoints', [])
 
     if (received.length === 0 && sent.length === 0) {
       return {}
@@ -229,30 +200,23 @@ export default class Monitors extends React.Component {
   render() {
     const { protocol } = this.props
 
-    if (protocol === 'http') {
-      return (
-        <>
-          <div className={styles.title}>
-            {t('Traffic (requests per second)')}
-          </div>
-          <TrafficCard metrics={this.trafficInMetrics} />
-          <div className="margin-b8" />
-          <Chart {...this.requestInMetrics} height={150} />
-        </>
-      )
-    }
-
     if (protocol === 'tcp') {
       return (
         <>
           <div className={styles.title}>{t('TCP_INBOUND_TRAFFIC')}</div>
           <Chart {...this.tcpInMetrics} height={150} />
-          <div className={styles.title}>{t('TCP_OUTBOUND_TRAFFIC')}</div>
-          <Chart {...this.tcpOutMetrics} height={150} />
         </>
       )
     }
 
-    return null
+    // for http and grpc
+    return (
+      <>
+        <div className={styles.title}>{t('Traffic (requests per second)')}</div>
+        <TrafficCard metrics={this.trafficInMetrics} />
+        <div className="margin-b8" />
+        <Chart {...this.requestInMetrics} height={150} />
+      </>
+    )
   }
 }

--- a/src/components/Graph/Detail/Monitors/WorkloadMonitor.jsx
+++ b/src/components/Graph/Detail/Monitors/WorkloadMonitor.jsx
@@ -172,6 +172,54 @@ export default class Monitors extends React.Component {
     })
   }
 
+  get tcpInMetrics() {
+    const { detail } = this.props
+    if (!detail) {
+      return []
+    }
+
+    const { metrics } = this.state
+    const received = get(metrics, 'tcp_received[0].datapoints', [])
+    const sent = get(metrics, 'tcp_sent[0].datapoints', [])
+
+    if (received.length === 0 && sent.length === 0) {
+      return {}
+    }
+
+    return getAreaChartOps({
+      title: 'bandwith',
+      legend: ['Send', 'Receive'],
+      data: [{ values: sent }, { values: received }],
+      unit: 'B/s',
+    })
+  }
+
+  get tcpOutMetrics() {
+    const { detail } = this.props
+    if (!detail) {
+      return {}
+    }
+
+    const { outMetrics } = this.state
+    const received = get(
+      outMetrics,
+      'metrics.tcp_received.matrix[0].values',
+      []
+    )
+    const sent = get(outMetrics, 'tcp_sent[0].datapoints', [])
+
+    if (received.length === 0 && sent.length === 0) {
+      return {}
+    }
+
+    return getAreaChartOps({
+      title: 'bandwith',
+      legend: ['Send', 'Receive'],
+      data: [{ values: sent }, { values: received }],
+      unit: 'B/s',
+    })
+  }
+
   get trafficInMetrics() {
     const { detail } = this.props
     if (!detail) {
@@ -282,6 +330,23 @@ export default class Monitors extends React.Component {
   }
 
   render() {
+    const { protocol } = this.props
+    if (protocol === 'tcp') {
+      return (
+        <>
+          <div className={styles.title}>
+            {t('TCP_INBOUND_TRAFFIC')} {this.renderWorkloadSelect()}
+          </div>
+          <Chart {...this.tcpInMetrics} height={150} />
+          <div className={styles.title}>
+            {t('TCP_OUTBOUND_TRAFFIC')} {this.renderWorkloadSelect()}
+          </div>
+          <Chart {...this.tcpOutMetrics} height={150} />
+        </>
+      )
+    }
+
+    // for http and grpc
     return (
       <>
         <div className={styles.title}>

--- a/src/stores/application/crd.js
+++ b/src/stores/application/crd.js
@@ -201,10 +201,8 @@ export default class ApplicationStore extends Base {
       duration: 60,
       step: 20,
       rateInterval: '20s',
-      'filters[]': ['request_count', 'request_duration', 'request_error_count'],
       direction: 'inbound',
-      reporter: 'destination',
-      requestProtocol: 'http',
+      reporter: 'source',
       ...options,
     }
     return request.get(
@@ -224,7 +222,6 @@ export default class ApplicationStore extends Base {
       rateInterval: '20s',
       direction: 'inbound',
       reporter: 'source',
-      requestProtocol: 'http',
       ...options,
     }
     return request.get(


### PR DESCRIPTION
Signed-off-by: Roland.Ma <rolandma@kubesphere.io>

### What type of PR is this?
/kind bug
### What this PR does / why we need it:
2 issues were fixed.
1. Service tab should only have inbound traffic data.
2. TCP traffic should be displayed in the Workload tab


### Which issue(s) this PR fixes:

Fixes# #https://github.com/kubesphere/kubesphere/issues/4498

### Special notes for reviewers:
![tcp-workload](https://user-images.githubusercontent.com/1720333/150761202-1ae42819-0e18-4f12-be1f-98c5aff9cf17.png)
![tcp service](https://user-images.githubusercontent.com/1720333/150761219-63e53716-b7f2-4ce9-8d68-c97909ac0599.png)

### Does this PR introduced a user-facing change?

```release-note
The TCP traffic data in traffic monitoring is empty
```

### Additional documentation, usage docs, etc.:
```docs

```

/cc @harrisonliu5 
