### PR TITLE
docs: Fix an improper description on a tab.

### DIFF
--- a/src/pages/projects/containers/ServiceAccounts/Detail/routes.js
+++ b/src/pages/projects/containers/ServiceAccounts/Detail/routes.js
@@ -23,7 +23,7 @@ import ServiceAccountDetail from './ServiceAccountDetail'
 export default path => [
   {
     path: `${path}/detail`,
-    title: 'RESOURCE_STATUS',
+    title: 'DATA',
     component: ServiceAccountDetail,
     exact: true,
   },


### PR DESCRIPTION
Signed-off-by: serenashe <serenashe@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind documentation

### What this PR does / why we need it:
Fix an improper description of a tab on the Service Accounts details page.

### Special notes for reviewers:
```
1. Log in to the KubeSphere web console.
2. Select Cluster Management > Configurations > Service Accounts.
3. Click the name of a service account to view its details page.
The change has been made on the service account details page. I changed **Resource Status** to **Data**, which, in my opinion, better describe this area.
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
/assign @Patrick-LuoYu @harrisonliu5 
Please take a look, thanks!
