### PR TITLE
Make required field determine whether the parameter is required

### DIFF
--- a/src/components/Forms/Pipelines/PipelineTemplateParams/params.jsx
+++ b/src/components/Forms/Pipelines/PipelineTemplateParams/params.jsx
@@ -47,7 +47,10 @@ export default function ParamsInput({ option }) {
         label={option.name}
         desc={option.description}
         rules={[
-          { required: !option.default, message: t('Please input value') },
+          {
+            required: option.required ?? false,
+            message: t('Please input value'),
+          },
         ]}
       >
         <Input


### PR DESCRIPTION
### What type of PR is this?

/kind optimization
/area devops

### What this PR does / why we need it:

Make required field decide whether the form item is required. 

We have decided to add a required field to determine whether the parameter is required to input instead of using `default` field. See
- https://github.com/kubesphere/ks-devops/pull/489

for more.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

Steps to test:

1. Apply a ClusterTemplate for test:
    ```bash
    cat <<'EOF' | kubectl apply -f -
    apiVersion: devops.kubesphere.io/v1alpha3
    kind: ClusterTemplate
    metadata:
      name: echo
    spec:
      parameters:
      - default: John
        name: 姓
        required: false
      - default: Niang
        name: 名
        required: true
      template: |
        pipeline {
          agent none
          stages {
            stage('echo') {
              steps {
                echo 'Hello, $(.params.姓)-$(.params.名)!'
              }
            }
          }
        }
    EOF
    ```
1. Create a Pipeline for test
2. Edit Pipeline and select the ClusterTemplate created just now
3. See the result
    ![image](https://user-images.githubusercontent.com/16865714/158749535-675c4783-7504-47af-be3d-fa590cd7141c.png)


### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```


