### PR TITLE
Remove default value of label field when agent type is kubernetes

### DIFF
--- a/src/pages/devops/components/Pipeline/Sider/index.jsx
+++ b/src/pages/devops/components/Pipeline/Sider/index.jsx
@@ -173,7 +173,7 @@ export default class Sider extends React.Component {
         return (
           <Form data={this.formData} ref={this.formRef}>
             <Form.Item label={t('label')} desc={t('')}>
-              <Input name="label" defaultValue="default" />
+              <Input name="label" />
             </Form.Item>
             <Form.Item
               label={t('yaml')}


### PR DESCRIPTION
### What type of PR is this?

/kind optimization
/area devops

### What this PR does / why we need it:

As I mentioned in the title, I remove default value of label field when editing Pipeline and select agent type into kubernetes.

See #2986 for more.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/16865714/158756142-c0092b32-614f-4a2f-89e8-aa62fdf58610.png)|![image](https://user-images.githubusercontent.com/16865714/158755950-c331d383-72ef-4e37-b7d0-c774fddef110.png)|

### Which issue(s) this PR fixes:

Fixes #2986 

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

```release-note
Remove default value of label field when editing Pipeline and select agent type into Kubernetes
```

### Additional documentation, usage docs, etc.:

```docs

```

/cc @kubesphere/sig-devops 
/cc @kubesphere/sig-console 