### PR TITLE
docs: Update UI text.

### DIFF
--- a/locales/en/l10n-clusterManagement-storage-storageClasses-list.js
+++ b/locales/en/l10n-clusterManagement-storage-storageClasses-list.js
@@ -43,7 +43,8 @@ module.exports = {
   VOLUME_EXPANSION: 'Volume Expansion',
   RECLAIM_POLICY: 'Reclaim Policy',
   ACCESS_MODE: 'Access Mode',
-  ACCESS_MODES_DESC: 'Select an access mode supported by the storage class.',
+  ACCESS_MODES_DESC:
+    'Select one or more access modes supported by the storage class.',
   STORAGE_SYSTEM: 'Storage System',
   VOLUME_BINDING_MODE: 'Volume Binding Mode',
   IMMEDIATE_BINDING: 'Immediate binding',

--- a/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
+++ b/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
@@ -192,7 +192,7 @@ export default class StorageClassSetting extends React.Component {
                     message: t('PARAMETER_REQUIRED'),
                   },
                 ]}
-                label={t('STORAGE_SYSTEM')}
+                label={t('PROVISIONER')}
               >
                 <Input name={'provisioner'} />
               </Form.Item>


### PR DESCRIPTION
Signed-off-by: serenashe <serenashe@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind documentation

### What this PR does / why we need it:
Correct an inconsistent name of a parameter in the Create Storage Class dialog box.
In the Create Storage Class dialog box, the name of the parameter is **Storage System**.
But on the storage class list page, the name of exactly the same parameter is **Provisioner**.
I consulted @stoneshi-yunify and we concluded that these two parameters should have a consistent name **Provisioner**.

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```
/assign @harrisonliu5 Please take a look and help merge this PR. Thx.
