### PR TITLE
Fix the default cluster name of the argo app destination

### DIFF
--- a/src/stores/cd.js
+++ b/src/stores/cd.js
@@ -180,11 +180,10 @@ export default class CDStore extends Base {
     })
 
     if (isEmpty(result)) {
-      const clusterName = Object.keys(globals.clusterConfig)[0]
       this.clustersList = [
         {
           server: 'https://kubernetes.default.svc',
-          name: clusterName,
+          name: 'in-cluster',
         },
       ]
     } else {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/area devops

### What this PR does / why we need it:
As I mentioned in the title. The default cluster name should be `in-cluster` instead of `default`.

Before:
<img width="749" alt="image" src="https://user-images.githubusercontent.com/1450685/160601836-945957f1-d448-4d99-aec2-5f047edad3d9.png">


After:
<img width="726" alt="image" src="https://user-images.githubusercontent.com/1450685/160601782-7930ba86-ed34-4bb6-8884-d68967e98fd5.png">


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
