### PR TITLE
fix: Disable management function in accounts and workspaces manage page when user login in a member cluster

### DIFF
--- a/server/controllers/view.js
+++ b/server/controllers/view.js
@@ -21,6 +21,7 @@ const {
   getKSConfig,
   getK8sRuntime,
   getOAuthInfo,
+  getClusterRole,
 } = require('../services/session')
 
 const {
@@ -34,13 +35,14 @@ const { client: clientConfig } = getServerConfig()
 
 const renderView = async ctx => {
   try {
+    const clusterRole = await getClusterRole(ctx)
     const [user, ksConfig, runtime] = await Promise.all([
-      getCurrentUser(ctx),
+      getCurrentUser(ctx, clusterRole),
       getKSConfig(),
       getK8sRuntime(ctx),
     ])
 
-    await renderIndex(ctx, { ksConfig, user, runtime })
+    await renderIndex(ctx, { ksConfig, user, runtime, clusterRole })
   } catch (err) {
     renderViewErr(ctx, err)
   }

--- a/src/pages/workspaces/containers/BaseInfo/index.jsx
+++ b/src/pages/workspaces/containers/BaseInfo/index.jsx
@@ -213,7 +213,7 @@ class BaseInfo extends React.Component {
       })
     }
 
-    if (actions.includes('manage')) {
+    if (actions.includes('manage') && globals.clusterRole !== 'member') {
       option.push({
         actionName: 'workspace.delete',
         onClick: this.handleDelete,


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

- Disable management function in accounts and workspaces manage page when user login in a member cluster.

- Update workspace related api's version, refer to this: [Refactor workspace API and introduced tenant v1alpha3 version](https://github.com/kubesphere/kubesphere/pull/4721).

### Which issue(s) this PR fixes:

Fixes ##[4610](https://github.com/kubesphere/kubesphere/issues/4610)

### Special notes for reviewers:
```
No management button in accounts and workspaces page.
```

![截屏2022-04-06 11 41 07](https://user-images.githubusercontent.com/33231138/161891414-fc72e4dc-52e1-4d26-92a0-f46eba5db8e6.png)


![截屏2022-04-06 11 44 03](https://user-images.githubusercontent.com/33231138/161891674-9943cf9d-e084-4373-94fb-cf4c8e45312a.png)


### Does this PR introduced a user-facing change?
```release-note
Disable management function in accounts and workspaces manage page when user login in a member cluster
```

### Additional documentation, usage docs, etc.:
