### PR TITLE
fix: The volumeBindingMode of the created storageClass is always 'Immediate'

### DIFF
--- a/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
+++ b/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
@@ -202,7 +202,7 @@ export default class StorageClassSetting extends React.Component {
             <Column>
               <Form.Item label={t('VOLUME_BINDING_MODE')}>
                 <Select
-                  name="metadata.VolumeBindingMode"
+                  name="volumeBindingMode"
                   options={this.volumeBindingMode}
                 ></Select>
               </Form.Item>

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -351,11 +351,11 @@ const getStorageClassTemplate = () => ({
   metadata: {
     name: '',
     annotations: {},
-    VolumeBindingMode: 'WaitForFirstConsumer',
   },
   parameters: {},
   reclaimPolicy: 'Delete',
   allowVolumeExpansion: 'false',
+  volumeBindingMode: 'WaitForFirstConsumer',
 })
 
 const getProjectTemplate = () => ({


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes ##3032

### Special notes for reviewers:
```
Now
```
![截屏2022-03-30 15 35 39](https://user-images.githubusercontent.com/33231138/160777089-9d811a6d-a127-4337-844c-d830827afb5e.png)


### Does this PR introduced a user-facing change?
```release-note
The volumeBindingMode of the created storageClass is always 'Immediate'
```

### Additional documentation, usage docs, etc.: