### PR TITLE
fix: Update parameters's key to lowercase

### DIFF
--- a/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
+++ b/src/components/Forms/StorageClass/StorageClassSettings/index.jsx
@@ -113,7 +113,7 @@ export default class StorageClassSetting extends React.Component {
               desc={t(left.desc.toUpperCase())}
             >
               <LeftComponent
-                name={`parameters.${left.key}`}
+                name={`parameters.${left.key.toLowerCase()}`}
                 {...omit(left, [
                   'type',
                   'key',
@@ -133,7 +133,7 @@ export default class StorageClassSetting extends React.Component {
                 desc={t(right.desc.toUpperCase())}
               >
                 <RightComponent
-                  name={`parameters.${right.key}`}
+                  name={`parameters.${right.key.toLowerCase()}`}
                   {...omit(right, ['type', 'key', 'desc'])}
                 />
               </Form.Item>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes ##3033

### Special notes for reviewers:
```
Now, the key of parameters is lowercase.
```
![截屏2022-03-30 15 25 33](https://user-images.githubusercontent.com/33231138/160775520-af3f5bdf-fb8f-49b1-9b23-17c751e95f65.png)


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: