### PR TITLE
feat: Support load the entire configmap as environment variables

### DIFF
--- a/locales/en/l10n-projects-applicationWorkloads-deployments-details.js
+++ b/locales/en/l10n-projects-applicationWorkloads-deployments-details.js
@@ -46,6 +46,16 @@ module.exports = {
   EDIT_SETTINGS: 'Edit Settings',
 
   // More > Edit Settings > Containers
+  CUSTOMIZATION: 'Customization',
+  REFER_CONFIGMAPS: 'Refer ConfigMap',
+  REFER_SECRETS: 'Refer Secret',
+  BULK_QUOTA: 'Bulk quote',
+  BULK_REFERENCE_CONFIGURATION:
+    'Bulk reference configuration dictionary or confidential dictionary',
+  BULK_REFERENCE_CONFIGURATION_DES:
+    'Bulk reference configuration dictionaries or confidential dictionaries as needed, custom types cannot be added in bulk.',
+  CANCEL_SELECT_ALL: 'Uncheck all',
+  KEY_IN_CONFIGURATION: 'Keys in the configuration',
   // More > Edit Settings > Volumes
   // More > Edit Settings > Volumes > Mount Volume
   // More > Edit Settings > Volumes > Mount Configmap or Secret

--- a/locales/zh/l10n-projects-applicationWorkloads-deployments-details.js
+++ b/locales/zh/l10n-projects-applicationWorkloads-deployments-details.js
@@ -22,13 +22,16 @@ module.exports = {
   TARGET_REVISION_EMPTY_DESC: '请选择目标修改记录。',
   TARGET_REVISION_RECORD: '目标修改记录',
   // More > Edit Autoscaling
-  CONFIGURE_AUTOSCALING_DESC: '设置系统根据目标 CPU 和内存用量自动调整容器组副本数量。',
+  CONFIGURE_AUTOSCALING_DESC:
+    '设置系统根据目标 CPU 和内存用量自动调整容器组副本数量。',
   EDIT_AUTOSCALING: '编辑自动扩缩',
   TARGET_CPU_USAGE_UNIT: '目标 CPU 用量（%）',
   AUTOSCALING: '自动扩缩',
   RESOURCE_NAME: '资源名称',
-  TARGET_CPU_USAGE_DESC: '当实际 CPU 用量大于/小于目标值时，系统自动减少/增加容器组副本数量。',
-  TARGET_MEMORY_USAGE_DESC: '当实际内存用量大于/小于目标值时，系统自动减少/增加容器组副本数量。',
+  TARGET_CPU_USAGE_DESC:
+    '当实际 CPU 用量大于/小于目标值时，系统自动减少/增加容器组副本数量。',
+  TARGET_MEMORY_USAGE_DESC:
+    '当实际内存用量大于/小于目标值时，系统自动减少/增加容器组副本数量。',
   MINIMUM_REPLICAS_DESC: '设置允许的最小容器组副本数量，默认值为 1。',
   MAXIMUM_REPLICAS_DESC: '设置允许的最大容器组副本数量，默认值为 1。',
   TARGET_MEMORY_USAGE_UNIT: '目标内存用量（MiB）',
@@ -37,6 +40,15 @@ module.exports = {
   // More > Edit Settings > Update Strategy
   EDIT_SETTINGS: '编辑设置',
   // More > Edit Settings > Containers
+  CUSTOMIZATION: '自定义',
+  REFER_CONFIGMAPS: '引用配置字典',
+  REFER_SECRETS: '引用保密字典',
+  BULK_QUOTA: '批量引用',
+  BULK_REFERENCE_CONFIGURATION: '批量引用配置字典或保密字典',
+  BULK_REFERENCE_CONFIGURATION_DES:
+    '根据需要批量引用配置字典或保密字典，自定义类型无法批量添加。',
+  CANCEL_SELECT_ALL: '取消全选',
+  KEY_IN_CONFIGURATION: '配置中的键',
   // More > Edit Settings > Volumes
   // More > Edit Settings > Volumes > Mount Volume
   // More > Edit Settings > Volumes > Mount Configmap or Secret
@@ -51,7 +63,8 @@ module.exports = {
   REPLICAS_DESIRED: '期望副本数',
   REPLICAS_CURRENT: '当前副本数',
   ADJUST_REPLICAS: '调整副本数量',
-  REPLICAS_SCALE_NOTIFY_CONTENT: '您确定将容器组副本数量调整为 <strong>{num}</strong> 吗？',
+  REPLICAS_SCALE_NOTIFY_CONTENT:
+    '您确定将容器组副本数量调整为 <strong>{num}</strong> 吗？',
   REPLICAS_SCALE_NOTIFY_CONFIRM: '确定（{seconds}s）',
   REPLICAS_SCALE_NOTIFY_CANCEL: '取消',
   // Resource Status > Autoscaling
@@ -65,7 +78,8 @@ module.exports = {
   VIEW_ALL_REPLICAS: '查看所有副本',
   SHOW_SELECTED_ONLY: '仅显示已选',
   MONITORING_SELECT_LIMIT_MSG: '最多可以选择 10 个资源。',
-  MONITORING_ALERT_DESC: '默认最多显示五个容器组副本的信息。您可以点击<b>查看所有副本</b>以查看所有容器组副本的信息。',
+  MONITORING_ALERT_DESC:
+    '默认最多显示五个容器组副本的信息。您可以点击<b>查看所有副本</b>以查看所有容器组副本的信息。',
   CURRENT_VALUE: '当前：{value}',
   // Environment Variables
   ENVIRONMENT_VARIABLE_PL: '环境变量',
@@ -73,5 +87,5 @@ module.exports = {
   EVENT_AGE: '发生时间',
   EVENT_AGE_DATA: '{lastTime}<br/>（近 {duration}发生 {count} 次)',
   EVENT_AGE_DATA_TWICE: '{lastTime}<br/>（近 {duration}发生 2 次）',
-  SOURCE: '来源'
-};
+  SOURCE: '来源',
+}

--- a/src/components/Forms/Workload/VolumeSettings/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/index.jsx
@@ -512,7 +512,6 @@ class VolumeSettings extends React.Component {
         containers={mergedContainers}
         cluster={this.cluster}
         namespace={this.namespace}
-        containers={mergedContainers}
         onSave={this.handleVolume}
         onCancel={this.resetState}
         isFederated={isFederated}

--- a/src/components/Inputs/EnvironmentInput/ArrowModal/index.jsx
+++ b/src/components/Inputs/EnvironmentInput/ArrowModal/index.jsx
@@ -1,0 +1,111 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { useState, useRef } from 'react'
+import { Button } from '@kube-design/components'
+import classNames from 'classnames'
+import styles from './index.scss'
+
+const ArrowModal = ({
+  children,
+  className,
+  text,
+  dataTest,
+  onOK,
+  modalHeight,
+}) => {
+  const buttonRef = useRef()
+  const [showModal, setShowModal] = useState(false)
+  const [modalPosition, setPosition] = useState({
+    x: '100%',
+    y: '100%',
+    y1: 0,
+    height: 32,
+  })
+
+  const hideModal = () => {
+    setShowModal(!showModal)
+  }
+
+  const handleOK = data => {
+    hideModal()
+    onOK(data)
+  }
+
+  const { className: componentClassName, ...rest } = children.props
+  const childNode = React.cloneElement(children, {
+    className: classNames(componentClassName, styles.modal, {
+      [styles.showModal]: showModal,
+    }),
+    style: {
+      top: modalPosition.y,
+      // triangle width is 12px
+      left: modalPosition.x - 12,
+    },
+    hideModal,
+    onOK: handleOK,
+    onCancel: hideModal,
+    ...rest,
+  })
+
+  const countPosition = () => {
+    const { x, y, height } = buttonRef.current.getBoundingClientRect()
+    const windowHeight = window.innerHeight
+    let y1 = y
+    const modalTop = windowHeight - modalHeight
+    const modalYMiddle = windowHeight - modalHeight / 2
+    const d1 = modalYMiddle - (y + modalPosition.height / 2)
+    if (d1 > 0) {
+      y1 = modalTop - d1
+    } else {
+      y1 = modalTop - 12
+    }
+    const triangleP = y + 7
+    setPosition({ x, y: y1, y1: triangleP, height })
+  }
+
+  const buttonClick = () => {
+    if (!showModal) {
+      countPosition()
+    }
+    setShowModal(!showModal)
+  }
+
+  return (
+    <div
+      className={classNames(styles.buttonModalBox, className)}
+      ref={buttonRef}
+    >
+      {childNode}
+      <Button onClick={buttonClick} data-test={dataTest}>
+        {text}
+      </Button>
+      <div
+        className={classNames(styles.triangle, {
+          [styles.showModal]: showModal,
+        })}
+        style={{
+          top: modalPosition.y1,
+          left: modalPosition.x,
+        }}
+      ></div>
+    </div>
+  )
+}
+
+export default ArrowModal

--- a/src/components/Inputs/EnvironmentInput/ArrowModal/index.scss
+++ b/src/components/Inputs/EnvironmentInput/ArrowModal/index.scss
@@ -1,0 +1,32 @@
+@import '~scss/variables';
+
+.buttonModalBox {
+  position: relative;
+  display: inline-block;
+}
+
+.modal {
+  position: fixed;
+  display: none;
+  z-index: 3000;
+  transform: translateX(-100%);
+}
+
+.triangle {
+  height: 18px;
+  width: 12px;
+  position: fixed;
+  display: none;
+  right: 12px;
+  top: 0px;
+  z-index: 3000;
+  transform: translateX(-100%);
+  border-top: 9px solid transparent;
+  border-right: none;
+  border-bottom: 9px solid transparent;
+  border-left: $white solid 12px;
+}
+
+.showModal {
+  display: block;
+}

--- a/src/components/Inputs/EnvironmentInput/ConfigOrSecret/index.jsx
+++ b/src/components/Inputs/EnvironmentInput/ConfigOrSecret/index.jsx
@@ -1,0 +1,240 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React, { Component } from 'react'
+import {
+  Button,
+  Alert,
+  RadioGroup,
+  RadioButton,
+  Select,
+  Icon,
+  Checkbox,
+} from '@kube-design/components'
+import { cloneDeep } from 'lodash'
+import classNames from 'classnames'
+import styles from './index.scss'
+
+export default class AddConfigOrSecret extends Component {
+  state = {
+    tab: 'configMaps',
+    chooseAll: false,
+    name: '',
+    list: [],
+  }
+
+  get tabs() {
+    return [
+      {
+        label: t('CONFIGMAP_PL'),
+        value: 'configMaps',
+      },
+      {
+        label: t('SECRET_PL'),
+        value: 'secrets',
+      },
+    ]
+  }
+
+  get options() {
+    const { configMaps, secrets } = this.props
+    const { tab } = this.state
+
+    return tab === 'configMaps'
+      ? configMaps.map(config => ({
+          label: config.name,
+          value: config.name,
+        }))
+      : secrets.map(secret => ({
+          label: secret.name,
+          value: secret.name,
+        }))
+  }
+
+  settingKeys = () => {
+    const { configMaps, secrets } = this.props
+    const { tab, name } = this.state
+    let list = []
+
+    if (name !== '') {
+      const data =
+        tab === 'configMaps'
+          ? configMaps.find(config => config.name === name)
+          : secrets.find(secret => secret.name === name)
+
+      list = Object.keys(data.data || {}).map(key => ({
+        label: key,
+        value: key,
+        checked: false,
+      }))
+    }
+    this.setState({
+      list,
+    })
+  }
+
+  handleRadioChange = radio => {
+    this.setState({
+      tab: radio,
+      name: '',
+      list: [],
+    })
+  }
+
+  handleAllChoose = () => {
+    const { list, allChoose } = this.state
+    const newList = cloneDeep(list)
+    this.setState({
+      allChoose: !allChoose,
+      list: newList.map(item => ({ ...item, checked: !allChoose })),
+    })
+  }
+
+  handleTypeChange = name => {
+    this.setState(
+      {
+        name,
+        list: [],
+      },
+      () => {
+        this.settingKeys()
+      }
+    )
+  }
+
+  handleKeyChecked = position => {
+    const { list } = this.state
+    const newList = cloneDeep(list)
+    newList[position].checked = !newList[position].checked
+    this.setState({
+      list: newList,
+    })
+  }
+
+  handleCancel = () => {
+    const { onCancel } = this.props
+    this.setState(
+      {
+        name: '',
+        list: [],
+      },
+      () => {
+        onCancel()
+      }
+    )
+  }
+
+  handleOk = () => {
+    const { onOK } = this.props
+    const { tab, name, list } = this.state
+    const keyType = tab === 'configMaps' ? 'configMapKeyRef' : 'secretKeyRef'
+    const data = list
+      .filter(item => item.checked)
+      .map(item => ({
+        name: item.value,
+        valueFrom: {
+          [keyType]: {
+            name,
+            key: item.value,
+          },
+        },
+      }))
+    onOK(data)
+  }
+
+  render() {
+    const { className, style } = this.props
+    const { tab, allChoose, name, list } = this.state
+
+    return (
+      <div className={classNames(className, styles.contentBox)} style={style}>
+        <div className={styles.content}>
+          <apn className={styles.title}>
+            {t('BULK_REFERENCE_CONFIGURATION')}
+          </apn>
+          <Alert
+            className={styles.tip}
+            message={t('BULK_REFERENCE_CONFIGURATION_DES')}
+          ></Alert>
+
+          <RadioGroup
+            defaultValue={tab}
+            buttonWidth={120}
+            wrapClassName={styles.tabs}
+            onChange={this.handleRadioChange}
+          >
+            {this.tabs.map(option => (
+              <RadioButton key={option.value} value={option.value}>
+                {option.label}
+              </RadioButton>
+            ))}
+          </RadioGroup>
+
+          <div className={styles.subTitle}>
+            <span>
+              {tab === 'configMaps' ? t('CONFIGMAP_PL') : t('SECRET_PL')}
+            </span>
+          </div>
+
+          <Select
+            className={styles.select}
+            prefixIcon={<Icon name={tab === 'configMaps' ? 'hammer' : 'key'} />}
+            options={this.options}
+            onChange={this.handleTypeChange}
+            value={name}
+          />
+
+          <div className={styles.subTitle}>
+            <span>{t('KEY_IN_CONFIGURATION')}</span>
+            {list.length > 0 && (
+              <span className={styles.allChoose} onClick={this.handleAllChoose}>
+                {allChoose ? t('CANCEL_SELECT_ALL') : t('SELECT_ALL')}
+              </span>
+            )}
+          </div>
+
+          <div className={styles.table}>
+            <div
+              className={classNames(styles.innerBox, {
+                [styles.scroll]: list.length > 4,
+              })}
+            >
+              {list.map((item, index) => (
+                <Checkbox
+                  className={classNames(styles.tableItem, {
+                    [styles.checked]: item.checked,
+                  })}
+                  checked={item.checked}
+                  onChange={() => this.handleKeyChecked(index)}
+                >
+                  {item.label}
+                </Checkbox>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className={styles.options}>
+          <Button onClick={this.handleCancel}>{t('CANCEL')}</Button>
+          <Button type="control" onClick={this.handleOk}>
+            {t('OK')}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/components/Inputs/EnvironmentInput/ConfigOrSecret/index.scss
+++ b/src/components/Inputs/EnvironmentInput/ConfigOrSecret/index.scss
@@ -1,0 +1,119 @@
+@import '~scss/variables';
+
+.contentBox {
+  display: flex;
+  width: 520px;
+  height: 492px;
+  background: $white;
+  box-shadow: 0px 8px 16px rgba(36, 46, 66, 0.28);
+  border-radius: 4px;
+  flex-direction: column;
+  text-align: left;
+
+  .content {
+    flex: 1;
+    height: 432px;
+    padding: 12px;
+
+    .title {
+      font-weight: 600;
+      font-size: 12px;
+      line-height: 20px;
+      color: $dark-color07;
+      display: block;
+    }
+
+    .tip {
+      margin: 12px 0px;
+    }
+
+    .tabs {
+      background: $light-color01;
+      border: 1px solid $light-color07;
+      box-sizing: border-box;
+      border-radius: 16px;
+    }
+
+    .subTitle {
+      font-weight: 400;
+      font-size: 12px;
+      line-height: 20px;
+      display: flex;
+      justify-content: space-between;
+      margin-top: 12px;
+
+      .allChoose {
+        color: $blue-color03;
+        cursor: pointer;
+        user-select: none;
+      }
+    }
+
+    .select {
+      width: 100%;
+      max-width: none;
+
+      :global {
+        .select-options {
+          position: absolute;
+          top: 32px !important;
+          left: 0 !important;
+        }
+      }
+    }
+
+    .table {
+      margin-top: 8px;
+      padding: 12px;
+      background: $light-color01;
+      border-radius: 4px;
+      height: 180px;
+
+      .innerBox {
+        height: 100%;
+
+        .tableItem {
+          width: 100%;
+          background: $white;
+          border-radius: 4px;
+          padding: 8px 12px;
+          margin-bottom: 4px;
+
+          &::after {
+            top: 11.75px;
+            left: 17.25px;
+          }
+
+          &:last-of-type {
+            margin-bottom: 0px;
+          }
+        }
+
+        .checked {
+          background: $dark-color07;
+
+          :global {
+            .label-value {
+              color: $white;
+            }
+          }
+        }
+      }
+    }
+  }
+
+  .options {
+    display: flex;
+    height: 60px;
+    align-items: center;
+    padding: 14px 20px;
+    justify-content: flex-end;
+    background: $light-color02;
+    border-radius: 0px 0px 4px 4px;
+    box-shadow: inset 0px 1px 0px $light-color06;
+  }
+}
+
+.scroll {
+  overflow-y: scroll;
+}

--- a/src/components/Inputs/EnvironmentInput/index.jsx
+++ b/src/components/Inputs/EnvironmentInput/index.jsx
@@ -19,17 +19,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { Button } from '@kube-design/components'
-
 import ConfigMapStore from 'stores/configmap'
 import SecretStore from 'stores/secret'
 import FederatedStore from 'stores/federated'
-import { get, isEmpty } from 'lodash'
+import { cloneDeep, get, isEmpty } from 'lodash'
 import { trigger } from 'utils/action'
+import AddConfigOrSecret from './ConfigOrSecret'
 
 import Item from './Item'
 import ArrayInput from '../ArrayInput'
 import styles from './index.scss'
+import ArrowModal from './ArrowModal'
 
 @trigger
 export default class EnvironmentInput extends React.Component {
@@ -80,22 +80,6 @@ export default class EnvironmentInput extends React.Component {
         secrets,
       })
     })
-  }
-
-  handleAddRef = () => {
-    this.handleGetResource()
-    const { value, onChange } = this.props
-    if (isEmpty(value)) {
-      return onChange([{ name: '', valueFrom: {} }])
-    }
-
-    if (value.length === 1 && value[0].name === '' && value[0].value === '') {
-      return onChange([{ name: '', valueFrom: {} }])
-    }
-
-    if (value.every(this.checkItemValid)) {
-      return onChange([...value, { name: '', valueFrom: {} }])
-    }
   }
 
   handleResourceData = (data, type) => {
@@ -181,6 +165,13 @@ export default class EnvironmentInput extends React.Component {
     !isEmpty(item.name) &&
     (!isEmpty(item.value) || !isEmpty(item.valueFrom))
 
+  handleBulkQuote = data => {
+    const newData = cloneDeep(data)
+    const { value, onChange } = this.props
+    const oldData = value ?? []
+    onChange([...oldData, ...newData])
+  }
+
   render() {
     const { ...rest } = this.props
     const { configMaps, secrets } = this.state
@@ -199,13 +190,16 @@ export default class EnvironmentInput extends React.Component {
               {t('or')}
               <a onClick={this.handleCreateSecrets}>{t('CREATE_SECRET')}</a>
             </span>
-            <Button
+            <ArrowModal
               className={styles.extraBtn}
-              onClick={this.handleAddRef}
-              data-test="add-env-configmap"
+              dataTest="add-env-configmap"
+              onOK={this.handleBulkQuote}
+              text={t('BULK_QUOTA')}
+              modalWidth={520}
+              modalHeight={492}
             >
-              {t('USE_CONFIGMAP_OR_SECRET')}
-            </Button>
+              <AddConfigOrSecret configMaps={configMaps} secrets={secrets} />
+            </ArrowModal>
           </>
         }
         {...rest}

--- a/src/components/Inputs/EnvironmentInput/index.scss
+++ b/src/components/Inputs/EnvironmentInput/index.scss
@@ -8,8 +8,9 @@
 
 .desc {
   float: left;
-  margin-top: 6px;
-  margin-right: 10px;
+  margin: auto;
+  max-width: 500px;
+  text-align: left;
 
   a {
     margin: 0 5px;
@@ -21,8 +22,24 @@
 }
 
 .formError {
-  border: solid 1px #ca2621 !important;
+  border: solid 1px $red-color03 !important;
 }
 .nameTip {
   margin-bottom: 8px;
+}
+
+.typeBox {
+  :global {
+    .select {
+      width: 130px;
+    }
+  }
+}
+
+.textContent {
+  width: 100px;
+  height: 100px;
+  background: $white;
+  box-shadow: 0px 8px 16px rgba(36, 46, 66, 0.28);
+  border-radius: 4px;
 }

--- a/src/components/Inputs/EnvironmentInput/index.test.js
+++ b/src/components/Inputs/EnvironmentInput/index.test.js
@@ -48,7 +48,7 @@ it('renders correctly', () => {
   const wrapper = mount(<EnvironmentInput {...props} />)
 
   let items = wrapper.find('EnvironmentInputItem')
-  let button = wrapper.find('button[data-test="add-env-configmap"]')
+  const button = wrapper.find('button[data-test="add-env-configmap"]')
   expect(items).toHaveLength(1)
   expect(items.first().find('input[name="name"]')).toHaveValue('')
   expect(items.first().find('input[name="value"]')).toHaveValue('')
@@ -58,13 +58,6 @@ it('renders correctly', () => {
   items = wrapper.find('EnvironmentInputItem')
   expect(items.first().find('input[name="name"]')).toHaveProp({ value: 'aaa' })
   expect(items.first().find('input[name="value"]')).toHaveProp({ value: 'bbb' })
-
-  button = wrapper.find('Button[data-test="add-env-configmap"]')
-  button.prop('onClick')()
-  expect(props.onChange).toHaveBeenCalledWith([
-    { name: 'aaa', value: 'bbb' },
-    { name: '', valueFrom: {} },
-  ])
 
   wrapper.setProps({
     value: [
@@ -102,7 +95,7 @@ it('renders correctly', () => {
   expect(items).toHaveLength(4)
   expect(items.at(1).find('Input[name="name"]')).toHaveProp({ value: 'xxx' })
   expect(items.at(1).find('Select[name="resource"]')).toHaveProp({
-    value: 'configmap-aaa',
+    value: 'aaa',
   })
   expect(items.at(1).find('Select[name="resourceKey"]')).toHaveProp({
     value: 'aaa',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #[#4410](https://github.com/kubesphere/kubesphere/issues/4410)

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/161249262-ef0a4bb5-f29e-49c6-91c5-a3adfef0a0b7.mov

### Does this PR introduced a user-facing change?
```release-note
Support load the entire configmap or secret as environment variables for a deployment.
```

### Additional documentation, usage docs, etc.: