### PR TITLE
feat: Add snapshot class management page

### DIFF
--- a/locales/en/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
+++ b/locales/en/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+module.exports = {
+  VOLUME_SNAPSHOT_CLASSES_PL: 'Volume Snapshot Classes',
+  VOLUME_SNAPSHOT_CLASSES_DESC:
+    'Just like StorageClass provides a way for administrators to describe the "classes" of storage they offer when provisioning a volume, VolumeSnapshotClass provides a way to describe the "classes" of storage when provisioning a volume snapshot.',
+
+  // List > Create
+  SNAPSHOT_CLASS_SETTINGS: 'Snapshot Class Settings',
+  DRIVER: 'Driver',
+  DRIVER_DESC: "Driver name should be the same as StorageClass's provisioner.",
+  DRIVER_EMPTY_DESC: 'Driver is required.',
+
+  // List > Delete
+  VOLUME_SNAPSHOT_CLASSES_LOW: 'Volume Snapshot Classes',
+}

--- a/locales/zh/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
+++ b/locales/zh/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
@@ -16,17 +16,18 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 module.exports = {
-  VOLUME_SNAPSHOT_CLASSES_PL: 'Volume Snapshot Classes',
-  VOLUME_SNAPSHOT_CLASSES: 'Volume Snapshot Classes',
+  VOLUME_SNAPSHOT_CLASSES_PL: '存储卷快照类型',
+  VOLUME_SNAPSHOT_CLASSES: '存储卷快照类型',
   VOLUME_SNAPSHOT_CLASSES_DESC:
-    'Just like StorageClass provides a way for administrators to describe the "classes" of storage they offer when provisioning a volume, VolumeSnapshotClass provides a way to describe the "classes" of storage when provisioning a volume snapshot.',
+    '就像StorageClass为管理员提供了一种方法来描述他们在配置卷时提供的存储 "类别"，VolumeSnapshotClass提供了一种方法来描述配置卷快照时的存储 "类别"。',
+  VolumeSnapshotClass: '存储卷快照类型',
 
   // List > Create
-  SNAPSHOT_CLASS_SETTINGS: 'Snapshot Class Settings',
-  DRIVER: 'Driver',
-  DRIVER_DESC: "Driver name should be the same as StorageClass's provisioner.",
-  DRIVER_EMPTY_DESC: 'Driver is required.',
+  SNAPSHOT_CLASS_SETTINGS: '快照类型设置',
+  DRIVER: '驱动',
+  DRIVER_DESC: '驱动程序名称应与StorageClass的供应者相同。',
+  DRIVER_EMPTY_DESC: '驱动是必须的。',
 
   // List > Delete
-  VOLUME_SNAPSHOT_CLASSES_LOW: 'Volume Snapshot Classes',
+  VOLUME_SNAPSHOT_CLASSES_LOW: '存储卷快照类型',
 }

--- a/locales/zh/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
+++ b/locales/zh/l10n-clusterManagement-storage-volumeSnapshotClasses-list.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+module.exports = {
+  VOLUME_SNAPSHOT_CLASSES_PL: 'Volume Snapshot Classes',
+  VOLUME_SNAPSHOT_CLASSES_DESC:
+    'Just like StorageClass provides a way for administrators to describe the "classes" of storage they offer when provisioning a volume, VolumeSnapshotClass provides a way to describe the "classes" of storage when provisioning a volume snapshot.',
+
+  // List > Create
+  SNAPSHOT_CLASS_SETTINGS: 'Snapshot Class Settings',
+  DRIVER: 'Driver',
+  DRIVER_DESC: "Driver name should be the same as StorageClass's provisioner.",
+  DRIVER_EMPTY_DESC: 'Driver is required.',
+
+  // List > Delete
+  VOLUME_SNAPSHOT_CLASSES_LOW: 'Volume Snapshot Classes',
+}

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -179,7 +179,7 @@ client:
                 name: volume-snapshot-classes,
                 title: VOLUME_SNAPSHOT_CLASSES_PL,
                 authKey: volumes,
-                # requiredClusterVersion: v3.3.0,
+                requiredClusterVersion: v3.3.0,
               }
             - { name: storageclasses, title: STORAGE_CLASS_PL }
         - name: monitoring-alerting

--- a/server/config.yaml
+++ b/server/config.yaml
@@ -175,6 +175,12 @@ client:
                 title: VOLUME_SNAPSHOT_PL,
                 authKey: volumes,
               }
+            - {
+                name: volume-snapshot-classes,
+                title: VOLUME_SNAPSHOT_CLASSES_PL,
+                authKey: volumes,
+                # requiredClusterVersion: v3.3.0,
+              }
             - { name: storageclasses, title: STORAGE_CLASS_PL }
         - name: monitoring-alerting
           title: MONITORING_AND_ALERTING

--- a/src/actions/volume.js
+++ b/src/actions/volume.js
@@ -34,6 +34,7 @@ import { MODULE_KIND_MAP } from 'utils/constants'
 import FORM_TEMPLATES from 'utils/form.templates'
 import formPersist from 'utils/form.persist'
 import FORM_STEPS, { APPLY_SNAPSHOT_FORM_STEPS } from 'configs/steps/volumes'
+import SnapshotClassSteps from 'configs/steps/volume.snapshot.class'
 
 export default {
   'volume.create': {
@@ -263,6 +264,34 @@ export default {
         store,
         detail,
         modal: EditBasicInfoModal,
+        ...props,
+      })
+    },
+  },
+  'snapshotClasses.create': {
+    on({ store, module, name, detail, cluster, success, ...props }) {
+      const kind = MODULE_KIND_MAP[module]
+      const steps = [...SnapshotClassSteps]
+      const formTemplate = {
+        [kind]: {
+          ...FORM_TEMPLATES.volumesnapshotclass(),
+        },
+      }
+      const modal = Modal.open({
+        onOk: async object => {
+          const data = object[kind]
+          await store.create(data, { cluster })
+          Modal.close(modal)
+          Notify.success({ content: t('CREATE_SUCCESSFUL') })
+          success && success()
+        },
+        module,
+        name: kind,
+        store,
+        detail,
+        formTemplate,
+        steps,
+        modal: CreateModal,
         ...props,
       })
     },

--- a/src/components/Forms/VolumeSnapshot/SnapshotClassSettings/index.jsx
+++ b/src/components/Forms/VolumeSnapshot/SnapshotClassSettings/index.jsx
@@ -1,0 +1,73 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { get } from 'lodash'
+import { Column, Columns, Form, Input, Select } from '@kube-design/components'
+import { MODULE_KIND_MAP } from 'utils/constants'
+
+export default class SnapshotClassSettings extends React.Component {
+  get formTemplate() {
+    const { formTemplate, module } = this.props
+    return get(formTemplate, MODULE_KIND_MAP[module], formTemplate)
+  }
+
+  get options() {
+    return [
+      {
+        label: 'Delete',
+        value: 'Delete',
+      },
+      {
+        label: 'Retain',
+        value: 'Retain',
+      },
+    ]
+  }
+
+  render() {
+    const { formRef } = this.props
+
+    return (
+      <div>
+        <Form data={this.formTemplate} ref={formRef}>
+          <Columns>
+            <Column>
+              <Form.Item
+                label={t('DRIVER')}
+                desc={t('DRIVER_DESC')}
+                rules={[{ required: true, message: t('DRIVER_EMPTY_DESC') }]}
+              >
+                <Input name="driver" autoFocus={true} />
+              </Form.Item>
+            </Column>
+            <Column>
+              <Form.Item label={t('DELETION_POLICY')}>
+                <Select
+                  name="deletionPolicy"
+                  defaultValue="Delete"
+                  options={this.options}
+                />
+              </Form.Item>
+            </Column>
+          </Columns>
+        </Form>
+      </div>
+    )
+  }
+}

--- a/src/configs/steps/volume.snapshot.class.js
+++ b/src/configs/steps/volume.snapshot.class.js
@@ -15,17 +15,15 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
-module.exports = {
-  VOLUME_SNAPSHOT_CLASSES_PL: 'Volume Snapshot Classes',
-  VOLUME_SNAPSHOT_CLASSES_DESC:
-    'Just like StorageClass provides a way for administrators to describe the "classes" of storage they offer when provisioning a volume, VolumeSnapshotClass provides a way to describe the "classes" of storage when provisioning a volume snapshot.',
 
-  // List > Create
-  SNAPSHOT_CLASS_SETTINGS: 'Snapshot Class Settings',
-  DRIVER: 'Driver',
-  DRIVER_DESC: "Driver name should be the same as StorageClass's provisioner.",
-  DRIVER_EMPTY_DESC: 'Driver is required.',
+import BaseInfo from 'components/Forms/StorageClass/BaseInfo'
+import SnapshotClassSettings from 'components/Forms/VolumeSnapshot/SnapshotClassSettings'
 
-  // List > Delete
-  VOLUME_SNAPSHOT_CLASSES_LOW: 'Volume Snapshot Classes',
-}
+export default [
+  { title: 'BASIC_INFORMATION', component: BaseInfo, required: true },
+  {
+    title: 'SNAPSHOT_CLASS_SETTINGS',
+    component: SnapshotClassSettings,
+    required: true,
+  },
+]

--- a/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/VolumeSnapshot/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/VolumeSnapshot/index.jsx
@@ -86,7 +86,7 @@ export default class VolumeSnapshot extends React.Component {
         render: (backupStatus, _) => (
           <Status
             type={backupStatus}
-            name={_.readyToUse ? t('READY') : t('UNREADY')}
+            name={_.readyToUse ? t('READY_PL') : t('UNREADY_PL')}
           />
         ),
       },

--- a/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/VolumeSnapshot/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/VolumeSnapshot/index.jsx
@@ -1,0 +1,142 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { observer, inject } from 'mobx-react'
+
+import { getLocalTime, getDisplayName } from 'utils'
+import VolumeSnapshotStore from 'stores/volumeSnapshot'
+
+import { Avatar, Panel, Status } from 'components/Base'
+import BaseTable from 'components/Tables/Base'
+
+import styles from './index.scss'
+
+@inject('detailStore')
+@observer
+export default class VolumeSnapshot extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.volumeSnapshotStore =
+      props.volumeSnapshotStore || new VolumeSnapshotStore()
+  }
+
+  get store() {
+    return this.props.detailStore
+  }
+
+  get storageClassName() {
+    return this.store.detail.name
+  }
+
+  componentDidMount() {
+    this.handleFetch()
+  }
+
+  handleFetch = (params = {}) => {
+    const { cluster, name } = this.store.detail
+    if (params.keyword) {
+      params.name = params.keyword
+      delete params.keyword
+    }
+
+    this.volumeSnapshotStore.fetchList({
+      volumeSnapshotClassName: name,
+      cluster,
+      ...params,
+    })
+  }
+
+  getColumns = () => {
+    return [
+      {
+        title: t('NAME'),
+        dataIndex: 'name',
+        render: (name, record) => (
+          <Avatar
+            icon="snapshot"
+            iconSize={40}
+            title={getDisplayName(record)}
+            to={`/clusters/${record.cluster}/projects/${record.namespace}/volume-snapshots/${name}`}
+            desc={record.snapshotClassName}
+            noLink
+          />
+        ),
+      },
+      {
+        title: t('STATUS'),
+        dataIndex: 'backupStatus',
+        width: '20.5%',
+        render: (backupStatus, _) => (
+          <Status
+            type={backupStatus}
+            name={_.readyToUse ? t('READY') : t('UNREADY')}
+          />
+        ),
+      },
+      {
+        title: t('CAPACITY'),
+        dataIndex: 'restoreSize',
+        width: '20.5%',
+        render: restoreSize => restoreSize,
+      },
+      {
+        title: t('CREATION_TIME_TCAP'),
+        dataIndex: 'createTime',
+        width: '20.5%',
+        render: time => getLocalTime(time).format('YYYY-MM-DD HH:mm:ss'),
+      },
+    ]
+  }
+
+  render() {
+    const {
+      data,
+      filters,
+      isLoading,
+      total,
+      page,
+      limit,
+    } = this.volumeSnapshotStore.list
+    const pagination = { total, page, limit }
+
+    return (
+      <Panel
+        title={t('VOLUME_SNAPSHOT_PL')}
+        loading={isLoading}
+        empty={t('NO_AVAILABLE_RESOURCE_VALUE', {
+          resource: t('VOLUME_SNAPSHOT'),
+        })}
+      >
+        <BaseTable
+          className={styles.table}
+          data={data}
+          columns={this.getColumns()}
+          searchType="name"
+          keyword={filters.name}
+          filters={filters}
+          placeholder={t('SEARCH_BY_NAME')}
+          pagination={pagination}
+          isLoading={isLoading}
+          onFetch={this.handleFetch}
+        />
+      </Panel>
+    )
+  }
+}

--- a/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/index.jsx
@@ -1,0 +1,178 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { isEmpty } from 'lodash'
+import { observer, inject } from 'mobx-react'
+import { Loading } from '@kube-design/components'
+
+import { getDisplayName, getLocalTime } from 'utils'
+import { trigger } from 'utils/action'
+import VolumeSnapshotClassesStore from 'stores/volumeSnapshotClasses'
+
+import DetailPage from 'projects/containers/Base/Detail'
+
+import getRoutes from './routes'
+
+@inject('rootStore')
+@observer
+@trigger
+export default class VolumeDetail extends React.Component {
+  store = new VolumeSnapshotClassesStore()
+
+  state = {
+    detail: {},
+  }
+
+  componentDidMount() {
+    this.fetchData()
+  }
+
+  get name() {
+    return 'VOLUME_SNAPSHOT_CLASSES'
+  }
+
+  get module() {
+    return 'volume-snapshot-classes'
+  }
+
+  get authKey() {
+    return 'volumes'
+  }
+
+  get listUrl() {
+    const { cluster } = this.props.match.params
+
+    return `/clusters/${cluster}/${this.module}`
+  }
+
+  fetchData = async () => {
+    const detail = await this.store.fetchDetail(this.props.match.params)
+    this.setState({
+      detail,
+    })
+  }
+
+  getOperations = () => {
+    const { cluster, namespace } = this.props.match.params
+    const { detail } = this.state
+
+    return [
+      {
+        key: 'edit',
+        icon: 'pen',
+        text: t('EDIT_INFORMATION'),
+        action: 'edit',
+        onClick: () => {
+          this.trigger('volume.snapshotContent.baseInfo.edit', {
+            store: this.store,
+            cluster,
+            namespace,
+            detail: this.store.detail,
+            success: this.fetchData,
+          })
+        },
+      },
+      {
+        key: 'editYaml',
+        icon: 'pen',
+        text: t('EDIT_YAML'),
+        action: 'edit',
+        onClick: async () => {
+          this.trigger('volume.snapshot.yaml.edit', {
+            store: this.store,
+            detail,
+            yaml: detail._originData,
+            success: this.fetchData,
+          })
+        },
+      },
+      {
+        key: 'delete',
+        icon: 'trash',
+        text: t('DELETE'),
+        action: 'delete',
+        onClick: () =>
+          this.trigger('resource.delete', {
+            title: `${t('DELETE')}${t('VOLUME_SNAPSHOT_CLASSES_PL')}`,
+            type: this.name,
+            detail,
+            success: this.returnTolist,
+          }),
+      },
+    ]
+  }
+
+  getAttrs = () => {
+    const { detail = {} } = this.store
+    const { createTime, driver, deletionPolicy } = detail
+
+    if (isEmpty(detail)) return null
+
+    return [
+      {
+        name: t('PROVISIONER'),
+        value: driver,
+      },
+      {
+        name: t('DELETION_POLICY'),
+        value: deletionPolicy,
+      },
+      {
+        name: t('CREATION_TIME_TCAP'),
+        value: getLocalTime(createTime).format('YYYY-MM-DD HH:mm:ss'),
+      },
+    ]
+  }
+
+  returnTolist = () => {
+    this.props.rootStore.routing.push(this.listUrl)
+  }
+
+  render() {
+    const stores = { detailStore: this.store }
+
+    if (this.store.isLoading && !this.store.detail.name) {
+      return <Loading className="ks-page-loading" />
+    }
+
+    const sideProps = {
+      module: this.module,
+      authKey: this.authKey,
+      name: getDisplayName(this.store.detail),
+      desc: this.store.detail.description,
+      attrs: this.getAttrs(),
+      operations: this.getOperations(),
+      icon: 'storage',
+      breadcrumbs: [
+        {
+          label: t('VOLUME_SNAPSHOT_CLASSES_PL'),
+          url: this.listUrl,
+        },
+      ],
+    }
+
+    return (
+      <DetailPage
+        stores={stores}
+        {...sideProps}
+        routes={getRoutes(this.props.match.path)}
+      />
+    )
+  }
+}

--- a/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/routes.js
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/Detail/routes.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { getIndexRoute } from 'utils/router.config'
+
+import VolumeSnapshot from './VolumeSnapshot'
+
+export default PATH => [
+  {
+    path: `${PATH}/volume-snapshot`,
+    title: 'VOLUME_SNAPSHOT',
+    exact: true,
+    component: VolumeSnapshot,
+  },
+  getIndexRoute({ path: PATH, to: `${PATH}/volume-snapshot`, exact: true }),
+]

--- a/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshotClasses/index.jsx
@@ -1,0 +1,141 @@
+import React from 'react'
+
+import withList, { ListPage } from 'components/HOCs/withList'
+import { Avatar } from 'components/Base'
+import Banner from 'components/Cards/Banner'
+import Table from 'components/Tables/List'
+import { getDisplayName, getLocalTime } from 'utils'
+
+import VolumeSnapshotClassesStore from 'stores/volumeSnapshotClasses'
+
+@withList({
+  store: new VolumeSnapshotClassesStore(),
+  module: 'volumesnapshotclasses',
+  authKey: 'volumes',
+  name: 'VOLUME_SNAPSHOT_CLASSES',
+  rowKey: 'uid',
+})
+export default class VolumeSnapshotClasses extends React.Component {
+  get itemActions() {
+    const { trigger, store, match, name } = this.props
+    const { cluster } = match.params
+    return [
+      {
+        key: 'edit',
+        icon: 'pen',
+        text: t('EDIT_TCAP'),
+        action: 'edit',
+        show: this.showAction,
+        onClick: async item => {
+          const data = await store.fetchDetail(item)
+          trigger('resource.baseinfo.edit', {
+            store,
+            detail: data,
+            cluster,
+            success: this.props.getData,
+          })
+        },
+      },
+      {
+        key: 'editYaml',
+        icon: 'pen',
+        text: t('EDIT_YAML'),
+        action: 'view',
+        show: this.showAction,
+        onClick: async item => {
+          const data = await store.fetchDetail(item)
+          trigger('volume.snapshot.yaml.edit', {
+            store,
+            detail: data,
+            yaml: data._originData,
+            success: this.props.getData,
+          })
+        },
+      },
+      {
+        key: 'delete',
+        icon: 'trash',
+        text: t('DELETE'),
+        action: 'delete',
+        show: this.showAction,
+        disabled: this.cantDelete,
+        onClick: item =>
+          trigger('resource.delete', {
+            type: name,
+            detail: item,
+            success: this.props.getData,
+          }),
+      },
+    ]
+  }
+
+  getColumns = () => {
+    const { getSortOrder, prefix } = this.props
+    return [
+      {
+        title: t('NAME'),
+        dataIndex: 'name',
+        search: true,
+        sorter: true,
+        sortOrder: getSortOrder('name'),
+        render: (name, record) => (
+          <Avatar
+            to={`${prefix}/${name}`}
+            title={getDisplayName(record)}
+            desc={record.description}
+          />
+        ),
+      },
+      {
+        title: t('VOLUME_SNAPSHOT'),
+        dataIndex: 'count',
+        isHideable: true,
+        width: '17.6%',
+      },
+      {
+        title: t('PROVISIONER'),
+        dataIndex: 'driver',
+        isHideable: true,
+        width: '17.6%',
+      },
+      {
+        title: t('DELETION_POLICY'),
+        dataIndex: 'deletionPolicy',
+        isHideable: true,
+        width: '17.6%',
+      },
+      {
+        title: t('CREATION_TIME_TCAP'),
+        dataIndex: 'createTime',
+        sorter: true,
+        isHideable: true,
+        width: '12.3%',
+        render: time => getLocalTime(time).format('YYYY-MM-DD HH:mm'),
+      },
+    ]
+  }
+
+  showCreate = () => {
+    this.props.trigger('snapshotClasses.create', {
+      name: 'Snapshot Classes',
+      module: 'volumesnapshotclass',
+      cluster: this.props.match.params.cluster,
+      success: this.props.routing.query,
+    })
+  }
+
+  render() {
+    const { tableProps, bannerProps } = this.props
+    return (
+      <ListPage {...this.props} noWatch>
+        <Banner {...bannerProps}></Banner>
+        <Table
+          {...tableProps}
+          columns={this.getColumns()}
+          itemActions={this.itemActions}
+          onCreate={this.showCreate}
+        />
+      </ListPage>
+    )
+  }
+}

--- a/src/pages/clusters/containers/Storage/VolumeSnapshots/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshots/index.jsx
@@ -65,7 +65,7 @@ export default class VolumesSnapshots extends React.Component {
   }
 
   renderBanner() {
-    if (this.store.ksVersion >= 3.3) {
+    if (this.store.ksVersion >= 3.0) {
       return (
         <Banner {...this.bannerProps} tips={this.tips} routes={this.routes} />
       )

--- a/src/pages/clusters/routes/detail.js
+++ b/src/pages/clusters/routes/detail.js
@@ -33,6 +33,7 @@ import Volume from 'projects/containers/Volumes/Detail'
 import VolumeSnapshotsDetail from 'projects/containers/VolumeSnapshots/Detail'
 import AlertPolicyDetail from 'projects/containers/Alerting/Policies/Detail'
 import VolumeSnapshotContent from '../containers/Storage/VolumeSnapshots/SnapshotContent/Detail'
+import SnapshotClassesDetail from '../containers/Storage/VolumeSnapshotClasses/Detail'
 import PV from '../containers/Storage/PV/detail'
 import ProjectLayout from '../layouts/Project'
 
@@ -99,6 +100,10 @@ export default [
   {
     path: `${PATH}/volume-snapshot-content/:name`,
     component: VolumeSnapshotContent,
+  },
+  {
+    path: `${PATH}/volume-snapshot-classes/:name`,
+    component: SnapshotClassesDetail,
   },
   {
     path: `${PATH}/projects/:namespace`,

--- a/src/pages/clusters/routes/index.js
+++ b/src/pages/clusters/routes/index.js
@@ -28,6 +28,7 @@ import Clusters from '../containers/Clusters'
 import Overview from '../containers/Overview'
 import StorageClasses from '../containers/Storage/StorageClasses'
 import VolumeSnapshots from '../containers/Storage/VolumeSnapshots'
+import VolumeSnapshotClasses from '../containers/Storage/VolumeSnapshotClasses'
 import Volumes from '../containers/Storage/Volumes'
 import Nodes from '../containers/Nodes'
 import EdgeNodes from '../containers/EdgeNodes/index'
@@ -185,6 +186,10 @@ export default [
           {
             path: `${PATH}/volume-snapshots`,
             component: VolumeSnapshots,
+          },
+          {
+            path: `${PATH}/volume-snapshot-classes`,
+            component: VolumeSnapshotClasses,
           },
           {
             path: `${PATH}/monitor-cluster`,

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -297,6 +297,7 @@ export const MODULE_KIND_MAP = {
   s2ibuilders: 'S2iBuilder',
   nodes: 'Node',
   volumesnapshots: 'VolumeSnapshot',
+  volumesnapshotclass: 'VolumeSnapshotClass',
   namespaces: 'Namespace',
   workspaces: 'WorkspaceTemplate',
   clusters: 'Cluster',

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -345,6 +345,17 @@ const getVolumeTemplate = ({ namespace }) => ({
   },
 })
 
+const getSnapshotClassTemplate = () => ({
+  apiVersion: 'snapshot.storage.k8s.io/v1beta1',
+  deletionPolicy: 'Delete',
+  driver: '',
+  kind: 'VolumeSnapshotClass',
+  metadata: {
+    name: '',
+    annotations: {},
+  },
+})
+
 const getStorageClassTemplate = () => ({
   apiVersion: 'storage.k8s.io/v1',
   kind: 'StorageClass',
@@ -717,6 +728,7 @@ const FORM_TEMPLATES = {
   globalroles: getGlobalRoleTemplate,
   workspaceroles: getWorkspaceRoleTemplate,
   volumes: getVolumeTemplate,
+  volumesnapshotclass: getSnapshotClassTemplate,
   storageclasses: getStorageClassTemplate,
   project: getProjectTemplate,
   limitRange: getLimitRangeTemplate,

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -1066,6 +1066,23 @@ const VolumeSnapshotContentMapper = detail => {
   }
 }
 
+const VolumeSnapshotClassesMapper = detail => {
+  const { metadata = {}, apiVersion, driver, deletionPolicy, kind } = detail
+  const { deletionTimestamp = '', creationTimestamp = '' } = metadata
+
+  return {
+    ...getBaseInfo(detail),
+    apiVersion,
+    driver,
+    deletionPolicy,
+    kind,
+    count: get(metadata, 'annotations["kubesphere.io/snapshot-count"]', 0),
+    creationTimestamp,
+    deletionTimestamp,
+    _originData: detail,
+  }
+}
+
 const ClusterMapper = item => {
   const conditions = keyBy(get(item, 'status.conditions', []), 'type')
   const configz = get(item, 'status.configz', {})
@@ -1408,6 +1425,7 @@ export default {
   imageBlob: ImageDetailMapper,
   volumesnapshots: VolumeSnapshotMapper,
   volumesnapshotcontents: VolumeSnapshotContentMapper,
+  volumesnapshotclasses: VolumeSnapshotClassesMapper,
   users: UserMapper,
   clusters: ClusterMapper,
   kkclusters: KKClusterMapper,


### PR DESCRIPTION

### What type of PR is this?
/kind feature


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
- The last part of work about ##2930
- Add snapshot class management page

### Special notes for reviewers:
- snapshot class list page
![截屏2022-04-06 15 17 54](https://user-images.githubusercontent.com/33231138/161918901-8b53141d-41ac-45c8-926d-4b3bf6a49ea0.png)

- snapshot class detail page

![截屏2022-04-06 15 18 03](https://user-images.githubusercontent.com/33231138/161919006-22d08d78-3185-4a4e-bb69-587af29cb157.png)

- create snapshot class

![截屏2022-04-06 15 25 52](https://user-images.githubusercontent.com/33231138/161919092-4d37faee-9f3c-4771-b898-ace08fbf07c9.png)

![截屏2022-04-06 15 26 13](https://user-images.githubusercontent.com/33231138/161919142-23415f76-e111-40d9-a6fc-59b55eca26ff.png)

### Does this PR introduced a user-facing change?
```release-note
Add snapshot class management page
```

### Additional documentation, usage docs, etc.:

`Requirements`: 
- KubeSphere version should be greater than 3.3
