### PR TITLE
feat: Add disk usage per hard disk

### DIFF
--- a/locales/en/l10n-clusterManagement-monitoring&Alerting-clusterStatus.js
+++ b/locales/en/l10n-clusterManagement-monitoring&Alerting-clusterStatus.js
@@ -82,6 +82,7 @@ module.exports = {
   PHYSICAL_RESOURCES_MONITORING: 'Physical Resource Monitoring',
   INODE_USAGE: 'Inode Usage',
   DISK_USAGE: 'Disk Usage',
+  DISK_USAGE_DETAILS: 'Disk Usage Details',
   AVERAGE_CPU_LOAD: 'Average CPU Load',
   DISK_THROUGHPUT: 'Disk Throughput',
   POD_STATUS: 'Pod Status',

--- a/locales/zh/l10n-clusterManagement-monitoring&Alerting-clusterStatus.js
+++ b/locales/zh/l10n-clusterManagement-monitoring&Alerting-clusterStatus.js
@@ -20,7 +20,8 @@ module.exports = {
   MONITORING_AND_ALERTING: '监控告警',
   // Banner
   CLUSTER_STATUS: '集群状态',
-  MONITORING_CLUSTER_DESC: '集群状态展示集群资源的概览和详情，您可以查看集群资源的监控数据和用量排行情况。',
+  MONITORING_CLUSTER_DESC:
+    '集群状态展示集群资源的概览和详情，您可以查看集群资源的监控数据和用量排行情况。',
   // Overview > Cluster Node Status
   CLUSTER_NODE_STATUS: '集群节点状态',
   ALL_NODES: '全部节点',
@@ -73,6 +74,7 @@ module.exports = {
   PHYSICAL_RESOURCES_MONITORING: '物理资源监控',
   INODE_USAGE: 'Inode 用量',
   DISK_USAGE: '磁盘用量',
+  DISK_USAGE_DETAILS: '磁盘用量明细',
   AVERAGE_CPU_LOAD: 'CPU 平均负载',
   DISK_THROUGHPUT: '磁盘吞吐',
   POD_STATUS: '容器组状态',
@@ -121,5 +123,5 @@ module.exports = {
   SORT_BY_NODE_LOAD1: '按 CPU 平均负载排行',
   SORT_BY_NAMESPACE_MEMORY_USAGE_WO_CACHE: '按内存用量排行',
   POD_USAGE: '容器组用量',
-  EXPORT: '导出'
-};
+  EXPORT: '导出',
+}

--- a/src/pages/clusters/containers/Nodes/Detail/Monitoring/index.jsx
+++ b/src/pages/clusters/containers/Nodes/Detail/Monitoring/index.jsx
@@ -35,6 +35,7 @@ const MetricTypes = {
   memory_utilisation: 'node_memory_utilisation',
   disk_utilisation: 'node_disk_size_utilisation',
   disk_inode_utilisation: 'node_disk_inode_utilisation',
+  device_size_utilisation: 'node_device_size_utilisation',
   disk_inode_usage: 'node_disk_inode_usage',
   disk_inode_total: 'node_disk_inode_total',
   disk_read_iops: 'node_disk_read_iops',
@@ -76,116 +77,139 @@ class Monitorings extends React.Component {
     })
   }
 
-  getMonitoringCfgs = () => [
-    {
-      type: 'utilisation',
-      title: 'CPU_USAGE',
-      unit: '%',
-      legend: ['CPU_USAGE'],
-      data: get(this.metrics, `${MetricTypes.cpu_utilisation}.data.result`),
-    },
-    {
-      type: 'load',
-      title: 'AVERAGE_CPU_LOAD',
-      legend: [
-        t('TIME_M', { num: 1 }),
-        t('TIME_M', { num: 5 }),
-        t('TIME_M', { num: 15 }),
-      ],
-      data: [
-        get(this.metrics, `${MetricTypes.cpu_load1}.data.result[0]`, {}),
-        get(this.metrics, `${MetricTypes.cpu_load5}.data.result[0]`, {}),
-        get(this.metrics, `${MetricTypes.cpu_load15}.data.result[0]`, {}),
-      ],
-    },
-    {
-      type: 'utilisation',
-      title: 'MEMORY_USAGE',
-      unit: '%',
-      legend: ['MEMORY_USAGE'],
-      data: get(this.metrics, `${MetricTypes.memory_utilisation}.data.result`),
-    },
-    {
-      type: 'utilisation',
-      title: 'DISK_USAGE',
-      unit: '%',
-      legend: ['USAGE'],
-      data: get(this.metrics, `${MetricTypes.disk_utilisation}.data.result`),
-    },
-    {
-      type: 'utilisation',
-      title: 'INODE_USAGE',
-      unit: '%',
-      legend: ['INODE_USAGE'],
-      data: get(
-        this.metrics,
-        `${MetricTypes.disk_inode_utilisation}.data.result`
-      ),
-      renderTooltip: () => {
-        const usageData = getChartData({
-          unit: '',
-          legend: ['USAGE'],
-          valuesData: [
-            get(
-              this.metrics,
-              `${MetricTypes.disk_inode_usage}.data.result[0].values`,
-              []
-            ),
-          ],
-        })
-        const totalData = getChartData({
-          unit: '',
-          legend: ['USAGE'],
-          valuesData: [
-            get(
-              this.metrics,
-              `${MetricTypes.disk_inode_total}.data.result[0].values`,
-              []
-            ),
-          ],
-        })
+  getMonitoringCfgs = () => {
+    const deviceUsage = get(
+      this.metrics,
+      `${MetricTypes.device_size_utilisation}.data.result`,
+      []
+    )
+    const legend = deviceUsage && deviceUsage.map(item => item.metric.device)
 
-        return <CustomTooltip usageData={usageData} totalData={totalData} />
+    return [
+      {
+        type: 'utilisation',
+        title: 'CPU_USAGE',
+        unit: '%',
+        legend: ['CPU_USAGE'],
+        data: get(this.metrics, `${MetricTypes.cpu_utilisation}.data.result`),
       },
-    },
-    {
-      type: 'iops',
-      title: 'IOPS',
-      legend: ['READ', 'WRITE'],
-      data: [
-        get(this.metrics, `${MetricTypes.disk_read_iops}.data.result[0]`, {}),
-        get(this.metrics, `${MetricTypes.disk_write_iops}.data.result[0]`, {}),
-      ],
-    },
-    {
-      type: 'throughput',
-      title: 'DISK_THROUGHPUT',
-      unitType: 'throughput',
-      legend: ['READ', 'WRITE'],
-      data: [
-        get(
+      {
+        type: 'load',
+        title: 'AVERAGE_CPU_LOAD',
+        legend: [
+          t('TIME_M', { num: 1 }),
+          t('TIME_M', { num: 5 }),
+          t('TIME_M', { num: 15 }),
+        ],
+        data: [
+          get(this.metrics, `${MetricTypes.cpu_load1}.data.result[0]`, {}),
+          get(this.metrics, `${MetricTypes.cpu_load5}.data.result[0]`, {}),
+          get(this.metrics, `${MetricTypes.cpu_load15}.data.result[0]`, {}),
+        ],
+      },
+      {
+        type: 'utilisation',
+        title: 'MEMORY_USAGE',
+        unit: '%',
+        legend: ['MEMORY_USAGE'],
+        data: get(
           this.metrics,
-          `${MetricTypes.disk_read_throughput}.data.result[0]`,
-          {}
+          `${MetricTypes.memory_utilisation}.data.result`
         ),
-        get(
+      },
+      {
+        type: 'utilisation',
+        title: 'DISK_USAGE_DETAILS',
+        unit: '%',
+        legend: ['AVERAGE_USAGE', ...legend],
+        data: [
+          get(this.metrics, `${MetricTypes.disk_utilisation}.data.result[0]`),
+          ...deviceUsage,
+        ],
+      },
+      {
+        type: 'utilisation',
+        title: 'INODE_USAGE',
+        unit: '%',
+        legend: ['INODE_USAGE'],
+        data: get(
           this.metrics,
-          `${MetricTypes.disk_write_throughput}.data.result[0]`,
-          {}
+          `${MetricTypes.disk_inode_utilisation}.data.result`
         ),
-      ],
-    },
-    {
-      type: 'bandwidth',
-      title: 'NETWORK_TRAFFIC',
-      unitType: 'bandwidth',
-      legend: ['OUT', 'IN'],
-      data: [
-        get(this.metrics, `${MetricTypes.net_transmitted}.data.result[0]`, {}),
-        get(this.metrics, `${MetricTypes.net_received}.data.result[0]`, {}),
-      ],
-    },
-  ]
+        renderTooltip: () => {
+          const usageData = getChartData({
+            unit: '',
+            legend: ['USAGE'],
+            valuesData: [
+              get(
+                this.metrics,
+                `${MetricTypes.disk_inode_usage}.data.result[0].values`,
+                []
+              ),
+            ],
+          })
+          const totalData = getChartData({
+            unit: '',
+            legend: ['USAGE'],
+            valuesData: [
+              get(
+                this.metrics,
+                `${MetricTypes.disk_inode_total}.data.result[0].values`,
+                []
+              ),
+            ],
+          })
+
+          return <CustomTooltip usageData={usageData} totalData={totalData} />
+        },
+      },
+      {
+        type: 'iops',
+        title: 'IOPS',
+        legend: ['READ', 'WRITE'],
+        data: [
+          get(this.metrics, `${MetricTypes.disk_read_iops}.data.result[0]`, {}),
+          get(
+            this.metrics,
+            `${MetricTypes.disk_write_iops}.data.result[0]`,
+            {}
+          ),
+        ],
+      },
+      {
+        type: 'throughput',
+        title: 'DISK_THROUGHPUT',
+        unitType: 'throughput',
+        legend: ['READ', 'WRITE'],
+        data: [
+          get(
+            this.metrics,
+            `${MetricTypes.disk_read_throughput}.data.result[0]`,
+            {}
+          ),
+          get(
+            this.metrics,
+            `${MetricTypes.disk_write_throughput}.data.result[0]`,
+            {}
+          ),
+        ],
+      },
+      {
+        type: 'bandwidth',
+        title: 'NETWORK_TRAFFIC',
+        unitType: 'bandwidth',
+        legend: ['OUT', 'IN'],
+        data: [
+          get(
+            this.metrics,
+            `${MetricTypes.net_transmitted}.data.result[0]`,
+            {}
+          ),
+          get(this.metrics, `${MetricTypes.net_received}.data.result[0]`, {}),
+        ],
+      },
+    ]
+  }
 
   render() {
     const { createTime } = this.store.detail


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/4532

### Special notes for reviewers:
![image](https://user-images.githubusercontent.com/17872673/162392677-be655d01-e912-4956-bcd4-7581fc96a29c.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
feat: Add disk usage per hard disk
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
