### PR TITLE
fix: Can't connect to the cluster which kubesphere version below v3.3

### DIFF
--- a/server/services/session.js
+++ b/server/services/session.js
@@ -210,11 +210,29 @@ const getUserDetail = async (token, clusterRole) => {
 
 const getWorkspaces = async (token, clusterRole) => {
   let workspaces = []
+  let version = 3.2
 
+  const backendVersion = await send_gateway_request({
+    method: 'GET',
+    url: `/kapis/version`,
+    token,
+  })
+  if (backendVersion) {
+    const _version = backendVersion.gitVersion.replace(/[^\d.]/g, '')
+    version = Number(
+      _version
+        .split('.')
+        .slice(0, 2)
+        .join('.')
+    )
+  }
   const url =
-    clusterRole === 'host'
-      ? '/kapis/tenant.kubesphere.io/v1alpha3/workspacetemplates'
-      : '/kapis/tenant.kubesphere.io/v1alpha3/workspaces'
+    version > 3.2
+      ? clusterRole === 'host'
+        ? '/kapis/tenant.kubesphere.io/v1alpha3/workspacetemplates'
+        : '/kapis/tenant.kubesphere.io/v1alpha3/workspaces'
+      : '/kapis/tenant.kubesphere.io/v1alpha2/workspaces'
+
   const resp = await send_gateway_request({
     method: 'GET',
     url,


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

+ If a user use latest console image(v3.3.0-alpha.0) to connect a cluster which kubesphere version is v3.2.1, it will be error

<img width="616" alt="截屏2022-04-11 18 14 16" src="https://user-images.githubusercontent.com/33231138/162719482-d76e445d-5823-4eee-bdf6-cb9d1404e8cf.png">

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
