### PR TITLE
fix: No description for routes item in cluster management page

### DIFF
--- a/src/pages/clusters/containers/Workload/Routes/index.jsx
+++ b/src/pages/clusters/containers/Workload/Routes/index.jsx
@@ -121,6 +121,7 @@ export default class Routers extends React.Component {
             icon={ICON_TYPES[module]}
             iconSize={40}
             title={getDisplayName(record)}
+            desc={record.description || '-'}
             isMultiCluster={record.isFedManaged}
             to={`/clusters/${cluster}/projects/${record.namespace}/${module}/${name}`}
           />


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes ##3057

### Special notes for reviewers:

![截屏2022-04-12 14 28 55](https://user-images.githubusercontent.com/33231138/162894957-6bc1b671-25ea-4660-bcd2-1e24153efd22.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
