### PR TITLE
fix: Environment variable display is occluded

### DIFF
--- a/src/components/Cards/Containers/EnvVariables/index.scss
+++ b/src/components/Cards/Containers/EnvVariables/index.scss
@@ -94,6 +94,9 @@
 
     .name {
       width: 40%;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
 
       & + div {
         width: 60%;


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>


### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes # #3073

### Special notes for reviewers:

![截屏2022-04-12 15 42 28](https://user-images.githubusercontent.com/33231138/162907531-dae75856-933f-44e4-85ad-306e8e88786f.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: