### PR TITLE
fix: Environment variables do not support key names containing hyphens (-) and periods (.)

### DIFF
--- a/src/components/Inputs/EnvironmentInput/Item.jsx
+++ b/src/components/Inputs/EnvironmentInput/Item.jsx
@@ -211,7 +211,7 @@ export default class EnvironmentInputItem extends React.Component {
 
   validEnvKey = debounce((value, target = {}) => {
     const { handleKeyError, handleInputError } = this.props
-    const status = !PATTERN_ENV_NAME.test(value)
+    const invalid = !PATTERN_ENV_NAME.test(value)
     if (value === '' && target.value === '') {
       handleKeyError()
       handleInputError()
@@ -219,7 +219,7 @@ export default class EnvironmentInputItem extends React.Component {
         keyError: false,
       })
     } else {
-      if (status) {
+      if (invalid) {
         const message =
           value !== ''
             ? t('ENVIRONMENT_INVALID_TIP')
@@ -231,7 +231,7 @@ export default class EnvironmentInputItem extends React.Component {
         handleInputError()
       }
       this.setState({
-        keyError: status,
+        keyError: invalid,
       })
     }
   }, 300)

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -565,7 +565,7 @@ export const PATTERN_PORT = /^([0-9]|[1-9]\d{1,3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]
 export const PATTERN_IMAGE_TAG = /^(.*?)([0-9a-zA-Z/]*)(:[-.\w]*[0-9a-zA-Z])*$/
 export const PATTERN_APPTEMPLATE_VERSION = /[a-zA-Z0-9](\.?-?[a-zA-Z0-9])+(\s?\[?[a-zA-Z0-9]+\.?-?\]?)*/
 export const PATTERN_UTC_TIME = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+Z/
-export const PATTERN_ENV_NAME = /^[^0-9][a-zA-Z0-9_]*$/
+export const PATTERN_ENV_NAME = /^[-._a-zA-Z][-._a-zA-Z0-9]*$/
 
 export const PIPELINE_TASKS = {
   All: [


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes # #3078

### Special notes for reviewers:

+ It will be error

![截屏2022-04-12 16 26 38](https://user-images.githubusercontent.com/33231138/162916269-22719691-99cf-410b-8c4f-2fc92ce97ef6.png)

+ No error

![截屏2022-04-12 16 25 56](https://user-images.githubusercontent.com/33231138/162916045-f8c08556-7c74-4a53-a487-d79a6e4d0028.png)


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: