### PR TITLE
fix: Remove the Version field on the Revision Records tab page

### DIFF
--- a/src/pages/projects/containers/Deployments/Detail/RevisionControl/index.jsx
+++ b/src/pages/projects/containers/Deployments/Detail/RevisionControl/index.jsx
@@ -20,7 +20,7 @@ import React from 'react'
 import { computed, toJS } from 'mobx'
 import { observer, inject } from 'mobx-react'
 
-import { get, sortBy } from 'lodash'
+import { sortBy } from 'lodash'
 
 import { getLocalTime } from 'utils'
 import { getValue } from 'utils/yaml'
@@ -150,10 +150,6 @@ class RevisionControl extends React.Component {
         {revision && (
           <Panel>
             <div className={styles.header}>
-              <Text
-                title={get(revision, 'labels.version', '-')}
-                description={t('VERSION')}
-              />
               <Text
                 title={`#${revision.revision}`}
                 description={t('SERIAL_NUMBER')}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>


### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes ##2987

### Special notes for reviewers:

![截屏2022-04-12 16 59 39](https://user-images.githubusercontent.com/33231138/162923371-daf8c592-a75a-4f36-a7f8-e0bb08033207.png)


### Does this PR introduced a user-facing change?
```release-note
Remove the Version field on the Revision Records tab page
```

### Additional documentation, usage docs, etc.:
