### PR TITLE
fix: StorageClass accessor manage URL error

### DIFF
--- a/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
+++ b/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
@@ -66,10 +66,17 @@ export default class StorageClassDetail extends React.Component {
     return `/clusters/${cluster}/storageclasses`
   }
 
+  get supportAccessor() {
+    const { params } = this.props.match
+    return this.accessorStore.getKsVersion(params) > 3.2
+  }
+
   fetchData = async () => {
     const { params } = this.props.match
     await this.store.fetchDetail(params)
-    this.checkHasAccessor()
+    if (this.supportAccessor) {
+      this.checkHasAccessor()
+    }
   }
 
   checkHasAccessor = async () => {
@@ -123,6 +130,7 @@ export default class StorageClassDetail extends React.Component {
       ),
       text: t('STORAGECLASS_ACCESSOR'),
       action: 'edit',
+      show: this.supportAccessor,
       onClick: () =>
         this.trigger('storageclass.accessor', {
           storageClassName: get(this.store.detail, 'name'),

--- a/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
+++ b/src/pages/clusters/containers/Storage/StorageClasses/Detail/index.jsx
@@ -26,6 +26,8 @@ import { trigger } from 'utils/action'
 import { toJS } from 'mobx'
 import StorageClassStore from 'stores/storageClass'
 import AccessorStore from 'stores/accessor'
+import ValidateWebhookCFStore from 'stores/validateWebhookCF'
+import CrdStore from 'stores/crd'
 import FORM_TEMPLATES from 'utils/form.templates'
 
 import DetailPage from 'clusters/containers/Base/Detail'
@@ -39,6 +41,14 @@ export default class StorageClassDetail extends React.Component {
   store = new StorageClassStore()
 
   accessorStore = new AccessorStore()
+
+  validateWebhookCFStore = new ValidateWebhookCFStore()
+
+  CrdStore = new CrdStore()
+
+  state = {
+    supportAccessor: true,
+  }
 
   componentDidMount() {
     this.store.fetchList({ limit: -1 })
@@ -66,15 +76,32 @@ export default class StorageClassDetail extends React.Component {
     return `/clusters/${cluster}/storageclasses`
   }
 
-  get supportAccessor() {
-    const { params } = this.props.match
-    return this.accessorStore.getKsVersion(params) > 3.2
-  }
-
   fetchData = async () => {
     const { params } = this.props.match
+    const ksVersion = await this.accessorStore.getKsVersion(params)
     await this.store.fetchDetail(params)
-    if (this.supportAccessor) {
+
+    if (ksVersion < 3.3) {
+      // check if k8s supports accessor resource
+      Promise.all([
+        this.validateWebhookCFStore.fetchDetailWithoutWarning({
+          ...params,
+          name: 'storageclass-accessor.storage.kubesphere.io',
+        }),
+        this.CrdStore.fetchDetailWithoutWarning({
+          ...params,
+          name: 'accessors.storage.kubesphere.io',
+        }),
+      ]).then(([validate, crd]) => {
+        if (!isEmpty(validate) && !isEmpty(crd)) {
+          this.checkHasAccessor()
+        } else {
+          this.setState({
+            supportAccessor: false,
+          })
+        }
+      })
+    } else {
       this.checkHasAccessor()
     }
   }
@@ -82,109 +109,112 @@ export default class StorageClassDetail extends React.Component {
   checkHasAccessor = async () => {
     const { params } = this.props.match
     const storageClassName = get(this.store.detail, 'name')
-    const allAccessors = await this.accessorStore.fetchListByK8s()
-    const hasYaml = allAccessors.filter(
-      item => item.metadata.name === `${storageClassName}-accessor`
-    )
-    if (hasYaml.length === 0) {
+    const detail = await this.accessorStore.fetchDetailWithoutWarning({
+      ...params,
+      name: `${storageClassName}-accessor`,
+    })
+    if (isEmpty(detail)) {
       const template = FORM_TEMPLATES['accessors'](storageClassName)
       await this.accessorStore.create(template)
+      await this.accessorStore.fetchDetail({ name: `${params.name}-accessor` })
     }
-    await this.accessorStore.fetchDetail({ name: `${params.name}-accessor` })
   }
 
-  getOperations = () => [
-    {
-      key: 'editYaml',
-      type: 'default',
-      text: t('EDIT_YAML'),
-      action: 'edit',
-      onClick: () =>
-        this.trigger('resource.yaml.edit', {
-          detail: toJS(this.store.detail),
-          readOnly: false,
-          success: this.fetchData,
-        }),
-    },
-    {
-      key: 'setDefault',
-      icon: 'pen',
-      text: t('SET_AS_DEFAULT_STORAGE_CLASS'),
-      action: 'edit',
-      onClick: () =>
-        this.trigger('storageclass.set.default', {
-          detail: toJS(this.store.detail),
-          defaultStorageClass: this.defaultStorageClass.name,
-          success: this.fetchData,
-        }),
-    },
-    {
-      key: 'accessor',
-      icon: () => (
-        <>
-          <img
-            src="/assets/storageclass-tree.svg"
-            style={{ width: '16px', marginRight: '12px' }}
-          />
-        </>
-      ),
-      text: t('STORAGECLASS_ACCESSOR'),
-      action: 'edit',
-      show: this.supportAccessor,
-      onClick: () =>
-        this.trigger('storageclass.accessor', {
-          storageClassName: get(this.store.detail, 'name'),
-          store: this.accessorStore,
-          detail: toJS(this.accessorStore.detail),
-          success: this.fetchData,
-        }),
-    },
-    {
-      key: 'funcManage',
-      icon: 'slider',
-      text: t('VOLUME_MANAGEMENT'),
-      action: 'edit',
-      onClick: () =>
-        this.trigger('storageclass.volume.function.update', {
-          detail: toJS(this.store.detail),
-          StorageClassStore: this.store,
-          success: this.fetchData,
-        }),
-    },
-    {
-      key: 'autoResizer',
-      icon: () => (
-        <>
-          <img
-            src="/assets/storageclass_autoresizer.svg"
-            style={{ width: '16px', marginRight: '12px' }}
-          />
-        </>
-      ),
-      text: t('PVC_AUTORESIZER_PL'),
-      action: 'edit',
-      onClick: () =>
-        this.trigger('storageclass.pvc.autoresizer', {
-          detail: toJS(this.store.detail),
-          StorageClassStore: this.store,
-          success: this.fetchData,
-        }),
-    },
-    {
-      key: 'delete',
-      icon: 'trash',
-      text: t('DELETE'),
-      action: 'delete',
-      type: 'danger',
-      onClick: () =>
-        this.trigger('storageclass.delete', {
-          type: this.name,
-          detail: toJS(this.store.detail),
-          accessorStore: this.accessorStore,
-          success: this.returnTolist,
-        }),
-    },
-  ]
+  getOperations = () => {
+    const { supportAccessor } = this.state
+    return [
+      {
+        key: 'editYaml',
+        type: 'default',
+        text: t('EDIT_YAML'),
+        action: 'edit',
+        onClick: () =>
+          this.trigger('resource.yaml.edit', {
+            detail: toJS(this.store.detail),
+            readOnly: false,
+            success: this.fetchData,
+          }),
+      },
+      {
+        key: 'setDefault',
+        icon: 'pen',
+        text: t('SET_AS_DEFAULT_STORAGE_CLASS'),
+        action: 'edit',
+        onClick: () =>
+          this.trigger('storageclass.set.default', {
+            detail: toJS(this.store.detail),
+            defaultStorageClass: this.defaultStorageClass.name,
+            success: this.fetchData,
+          }),
+      },
+      {
+        key: 'accessor',
+        icon: () => (
+          <>
+            <img
+              src="/assets/storageclass-tree.svg"
+              style={{ width: '16px', marginRight: '12px' }}
+            />
+          </>
+        ),
+        text: t('STORAGECLASS_ACCESSOR'),
+        action: 'edit',
+        show: supportAccessor,
+        onClick: () =>
+          this.trigger('storageclass.accessor', {
+            storageClassName: get(this.store.detail, 'name'),
+            store: this.accessorStore,
+            detail: toJS(this.accessorStore.detail),
+            success: this.fetchData,
+          }),
+      },
+      {
+        key: 'funcManage',
+        icon: 'slider',
+        text: t('VOLUME_MANAGEMENT'),
+        action: 'edit',
+        onClick: () =>
+          this.trigger('storageclass.volume.function.update', {
+            detail: toJS(this.store.detail),
+            StorageClassStore: this.store,
+            success: this.fetchData,
+          }),
+      },
+      {
+        key: 'autoResizer',
+        icon: () => (
+          <>
+            <img
+              src="/assets/storageclass_autoresizer.svg"
+              style={{ width: '16px', marginRight: '12px' }}
+            />
+          </>
+        ),
+        text: t('PVC_AUTORESIZER_PL'),
+        action: 'edit',
+        onClick: () =>
+          this.trigger('storageclass.pvc.autoresizer', {
+            detail: toJS(this.store.detail),
+            StorageClassStore: this.store,
+            success: this.fetchData,
+          }),
+      },
+      {
+        key: 'delete',
+        icon: 'trash',
+        text: t('DELETE'),
+        action: 'delete',
+        type: 'danger',
+        onClick: () =>
+          this.trigger('storageclass.delete', {
+            type: this.name,
+            detail: toJS(this.store.detail),
+            accessorStore: this.accessorStore,
+            success: this.returnTolist,
+          }),
+      },
+    ]
+  }
 
   getAttrs = () => {
     const { detail = {} } = this.store

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, set } from 'lodash'
+import { get, isEmpty, set } from 'lodash'
 import { action, observable } from 'mobx'
 import ObjectMapper from 'utils/object.mapper'
 
@@ -197,6 +197,21 @@ export default class BaseStore {
 
     const result = await request.get(this.getDetailUrl(params))
     const detail = { ...params, ...this.mapper(result) }
+
+    this.detail = detail
+    this.isLoading = false
+    return detail
+  }
+
+  @action
+  async fetchDetailWithoutWarning(params) {
+    this.isLoading = true
+
+    const result = await request.get(this.getDetailUrl(params), {}, {}, () => {
+      return {}
+    })
+
+    const detail = !isEmpty(result) ? { ...params, ...this.mapper(result) } : {}
 
     this.detail = detail
     this.isLoading = false

--- a/src/stores/validateWebhookCF.js
+++ b/src/stores/validateWebhookCF.js
@@ -1,0 +1,23 @@
+/*
+ * This file is part of KubeSphere Console.
+ * Copyright (C) 2019 The KubeSphere Console Authors.
+ *
+ * KubeSphere Console is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * KubeSphere Console is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import Base from './base'
+
+export default class ValidateWebhookCFStore extends Base {
+  module = 'validatingwebhookconfigurations'
+}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -926,6 +926,7 @@ export const API_VERSIONS = {
   nodes: 'api/v1',
   storageclasses: 'apis/storage.k8s.io/v1',
   accessors: 'apis/storage.kubesphere.io/v1alpha1',
+  validatingwebhookconfigurations: '/apis/admissionregistration.k8s.io/v1',
   roles: 'apis/rbac.authorization.k8s.io/v1',
   clusterroles: 'apis/rbac.authorization.k8s.io/v1',
   applications: 'apis/app.k8s.io/v1beta1',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

If the user uses the latest version console to connect the cluster which version is v3.2.1, here will has an error as follows:

![截屏2022-04-12 18 11 41](https://user-images.githubusercontent.com/33231138/162937771-0a1c2c99-cdca-4034-9a77-f91d57072890.png)

~~So this management function needs kubesphere version greater than 3.3.~~

 So we should check if k8s supports accessor resource when kubesphere verison below 3.3.
### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
