### PR TITLE
fix: Remove 'update kubeconfig' and 'unbind cluster' button in host cluster card

### DIFF
--- a/src/pages/clusters/containers/Clusters/index.jsx
+++ b/src/pages/clusters/containers/Clusters/index.jsx
@@ -112,12 +112,13 @@ class Clusters extends React.Component {
     this.routing.push(`/clusters/${cluster}/overview`)
   }
 
-  get itemActions() {
-    return [
+  getItemActions = item => {
+    const actions = [
       {
         key: 'pen',
         icon: 'pen',
         text: t('EDIT_INFORMATION'),
+        show: true,
         onClick: record => {
           this.trigger('resource.baseinfo.edit', {
             detail: record,
@@ -130,6 +131,7 @@ class Clusters extends React.Component {
         key: 'data',
         icon: 'data',
         text: t('UPDATE_KUBECONFIG'),
+        show: !item.isHost,
         onClick: record => {
           this.trigger('cluster.updateKubeConfig', {
             detail: record,
@@ -141,6 +143,7 @@ class Clusters extends React.Component {
         key: 'trash',
         icon: 'trash',
         text: t('UNBIND_CLUSTER'),
+        show: !item.isHost,
         onClick: record => {
           this.trigger('cluster.unbind', {
             detail: record,
@@ -149,6 +152,8 @@ class Clusters extends React.Component {
         },
       },
     ]
+
+    return actions.filter(action => action.show)
   }
 
   renderList() {
@@ -223,7 +228,7 @@ class Clusters extends React.Component {
                 data={item}
                 onEnter={this.enterCluster}
                 isOperation={this.isOperation}
-                itemActions={this.itemActions}
+                itemActions={this.getItemActions(item)}
               />
             ))}
           </div>
@@ -240,7 +245,7 @@ class Clusters extends React.Component {
                 data={item}
                 onEnter={this.enterCluster}
                 isOperation={this.isOperation}
-                itemActions={this.itemActions}
+                itemActions={this.getItemActions(item)}
               />
             ))}
             <div className="text-right margin-t12">


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3097

### Special notes for reviewers:

![截屏2022-04-13 16 14 00](https://user-images.githubusercontent.com/33231138/163131611-0eb1f00d-0555-410a-9131-08b8dc75c600.png)

![截屏2022-04-13 16 15 49](https://user-images.githubusercontent.com/33231138/163131720-e598593d-9b81-41e4-a195-ec8e3c1f7faa.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
