### PR TITLE
fix: Service topology map container monitoring's data doesn't change with the data request

### DIFF
--- a/src/pages/projects/containers/Services/Topology/Detail/Containers/index.jsx
+++ b/src/pages/projects/containers/Services/Topology/Detail/Containers/index.jsx
@@ -20,6 +20,7 @@ import React, { Component } from 'react'
 import { get } from 'lodash'
 import { Select } from '@kube-design/components'
 import ContainerMonitorStore from 'stores/monitoring/container'
+import { observer } from 'mobx-react'
 import styles from './index.scss'
 import PhysicalResourceItem from '../../../../Overview/ResourceUsage/PhysicalResourceItem'
 
@@ -28,6 +29,7 @@ const MetricTypes = {
   memory_usage: 'container_memory_usage_wo_cache',
 }
 
+@observer
 export default class Containers extends Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>



### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3108

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/163371048-efe52134-ba58-4152-bbf5-59f0ed15fbe8.mov


### Does this PR introduced a user-facing change?
```release-note
 Service topology map container monitoring's data doesn't change with the data request
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
