### PR TITLE
fix: Fix the data is residual when after is created the custom monitor

### DIFF
--- a/src/components/Forms/Dashboard/BaseInfo/index.jsx
+++ b/src/components/Forms/Dashboard/BaseInfo/index.jsx
@@ -32,10 +32,15 @@ export default class BaseInfo extends React.Component {
     super(props)
 
     if (isEmpty(this.formTemplate.spec)) {
-      const defaultKey = Object.keys(templateSettings)[0]
-      const defaultValue = cloneDeep(templateSettings[defaultKey].settings)
+      const defaultKey = Object.keys(this.templateSettings)[0]
+      const defaultValue = cloneDeep(this.templateSettings[defaultKey].settings)
+
       set(this.formTemplate, 'spec', defaultValue)
     }
+  }
+
+  get templateSettings() {
+    return cloneDeep(templateSettings)
   }
 
   get formTemplate() {
@@ -43,7 +48,7 @@ export default class BaseInfo extends React.Component {
     return get(formTemplate, MODULE_KIND_MAP[module], formTemplate)
   }
 
-  templateSettingsOpts = Object.entries(templateSettings)
+  templateSettingsOpts = Object.entries(this.templateSettings)
     .map(([key, configs]) => ({
       value: key,
       image: configs.logo,
@@ -77,7 +82,11 @@ export default class BaseInfo extends React.Component {
   }
 
   handleTemplateChange = key => {
-    set(this.formTemplate, 'spec', get(templateSettings, `${key}.settings`, {}))
+    set(
+      this.formTemplate,
+      'spec',
+      get(this.templateSettings, `${key}.settings`, {})
+    )
     this.forceUpdate()
   }
 


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/console/issues/3115

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 Fix the data is residual when after is created the custom monitor
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
