### PR TITLE
fix: Backend is lack of accessor crd will create 404 warning

### DIFF
--- a/locales/en/l10n-clusterManagement-storage-storageClasses-details.js
+++ b/locales/en/l10n-clusterManagement-storage-storageClasses-details.js
@@ -32,6 +32,8 @@ module.exports = {
   AUTHORIZATION_RULES: 'Authorization Rules',
   AUTHORIZATION_RULES_DESC:
     'Set authorization rules so that the storage class can be accessed only in specific projects and workspaces.',
+  AUTHORIZATION_NOT_SUPPORT:
+    'Your cluster is lack of accessor custom resources, please upgrade ks-installer to v3.3.0 and above, or install <a href="https://github.com/kubesphere/storageclass-accessor" target="_blank">storageclass-accessor</a> component manually',
   OPERATOR_IN: 'In',
   OPERATOR_NOT_IN: 'Not in',
 

--- a/src/actions/storageclass.js
+++ b/src/actions/storageclass.js
@@ -175,7 +175,7 @@ export default {
     },
   },
   'storageclass.accessor': {
-    on({ cluster, store, detail, storageClassName, success }) {
+    on({ cluster, store, detail, storageClassName, success, shouldAddCrd }) {
       const modal = Modal.open({
         onOk: async newObject => {
           Modal.close(modal)
@@ -187,6 +187,7 @@ export default {
         cluster,
         store,
         detail,
+        shouldAddCrd,
         modal: Accessor,
       })
     },

--- a/src/pages/clusters/components/Modals/Accessor/index.jsx
+++ b/src/pages/clusters/components/Modals/Accessor/index.jsx
@@ -19,7 +19,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Modal, Text, Switch } from 'components/Base'
-import { Select } from '@kube-design/components'
+import { Alert, Select } from '@kube-design/components'
 import WorkspaceStore from 'stores/workspace'
 import ProjectStore from 'stores/project'
 import { get, set, cloneDeep } from 'lodash'
@@ -191,7 +191,7 @@ export default class AccessorModal extends Component {
   }
 
   render() {
-    const { visible, onCancel, isSubmitting } = this.props
+    const { visible, onCancel, isSubmitting, shouldAddCrd } = this.props
     const { enabled, nsValues, wsValues, nsOpt, wsOpt } = this.state
 
     return (
@@ -204,7 +204,11 @@ export default class AccessorModal extends Component {
         okText={t('OK')}
         cancelText={t('CANCEL')}
         isSubmitting={isSubmitting}
+        hideFooter={shouldAddCrd}
       >
+        {shouldAddCrd && (
+          <Alert type="warning" message={t.html('AUTHORIZATION_NOT_SUPPORT')} />
+        )}
         <div className={styles.wrapper}>
           <Text
             className={styles.text}

--- a/src/stores/base.js
+++ b/src/stores/base.js
@@ -205,11 +205,27 @@ export default class BaseStore {
 
   @action
   async fetchDetailWithoutWarning(params) {
+    let urlNotSupport = false
     this.isLoading = true
 
-    const result = await request.get(this.getDetailUrl(params), {}, {}, () => {
-      return {}
-    })
+    const result = await request.get(
+      this.getDetailUrl(params),
+      {},
+      {},
+      (error, response) => {
+        if (error) {
+          if (error.status === 404) {
+            urlNotSupport = true
+          }
+          return {}
+        }
+        return response
+      }
+    )
+
+    if (urlNotSupport) {
+      return { urlNotSupport }
+    }
 
     const detail = !isEmpty(result) ? { ...params, ...this.mapper(result) } : {}
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

If kubesphere backend is lack of accessor CRD, it will create 404 warning as follow:

![截屏2022-04-18 17 06 33](https://user-images.githubusercontent.com/33231138/163785482-4b89df35-6306-43c0-a7cb-fbcd1cf268ce.png)

So we should prompt the user to upgrade the ks-installer to v3.3.0 and above or manually install the storageclass-accessor component.

### Which issue(s) this PR fixes:

### Special notes for reviewers:

![截屏2022-04-18 17 44 34](https://user-images.githubusercontent.com/33231138/163790590-bf827555-f538-468e-bb3d-e964d5f3ee45.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: