### PR TITLE
Support creates a role that can only trigger a Pipeline

### DIFF
--- a/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
@@ -47,7 +47,7 @@ export default class Activity extends React.Component {
   get enabledActions() {
     const { devops, cluster } = this.props.match.params
     return globals.app.getActions({
-      module: 'pipelines',
+      module: 'pipelineruns',
       cluster,
       devops,
     })

--- a/src/pages/devops/containers/Pipelines/Detail/Layout/branch.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/Layout/branch.jsx
@@ -41,7 +41,7 @@ import './index.scss'
 export default class BranchDetailLayout extends React.Component {
   sonarqubeStore = new CodeQualityStore()
 
-  module = 'pipelines'
+  module = 'pipelineruns'
 
   get store() {
     return this.props.pipelineStore


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
/area devops

### What this PR does / why we need it:
Many users hope they can create a single role to only support trigger Pipelines instead of having full control of the Pipeline management permission.

With this PR, users can do it. Please see the following screenshot (including regular and multi-branch Pipelines):

![image](https://user-images.githubusercontent.com/1450685/164024806-cba268bf-88f8-4f43-b4db-82a6b7c1febe.png)

![image](https://user-images.githubusercontent.com/1450685/164017776-66fa4c80-4fcc-4bc5-b76e-290aad1bf13c.png)

![image](https://user-images.githubusercontent.com/1450685/164022808-1eb0647f-f470-48ba-b949-9aefaeae6831.png)

![image](https://user-images.githubusercontent.com/1450685/164022867-05ed68b5-bb86-4635-9181-8554f878833e.png)

![image](https://user-images.githubusercontent.com/1450685/164023135-a6c49832-1f0e-4061-9666-cd61ba61ab1f.png)

![image](https://user-images.githubusercontent.com/1450685/164024094-c71f9493-0fca-4d23-8c9c-fc23b4fad0ba.png)

See also the original feature request from [the KubeSphere Chinese forum](https://kubesphere.com.cn/forum/d/4048-devopsbug/4).

fix https://github.com/kubesphere/ks-devops/issues/155
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
hi @harrisonliu5 , I'm not familiar with the front-end code base. Please help me to review this PR. Thanks!

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Support creates a role that can only trigger a Pipeline
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
