### PR TITLE
fix: Bars of a custom monitoring dashboard exceed the boundary

### DIFF
--- a/src/components/Modals/CustomMonitoring/components/Graph/Compose/index.jsx
+++ b/src/components/Modals/CustomMonitoring/components/Graph/Compose/index.jsx
@@ -38,6 +38,7 @@ const debounce = 100
 const defaultTickCount = 5
 const tickWidth = 75
 const defaultAreaOpacity = 0.4
+const barPadding = 30
 
 const generateTimeTick = function({ from, to, count }) {
   const timeDistance = to - from
@@ -116,6 +117,28 @@ export default class ComposeCustomChart extends React.PureComponent {
     }
   }
 
+  get singleBarSize() {
+    const { legends } = this.props
+    const size = this.XAxisShouldPadding
+      ? Math.floor((2 * barPadding) / legends.length)
+      : undefined
+    return size
+  }
+
+  get XAxisShouldPadding() {
+    const { data, timeRange } = this.props
+    const format = 'YYYY-MM-DD HH:mm:ss'
+
+    if (data.length === 1) {
+      const start = moment(timeRange.start).format(format)
+      const end = moment(timeRange.end).format(format)
+      const firstTime = moment(data[0].time).format(format)
+      return firstTime === start || firstTime === end
+    }
+
+    return false
+  }
+
   render() {
     const {
       data,
@@ -161,7 +184,7 @@ export default class ComposeCustomChart extends React.PureComponent {
                   /*
                    * fix the bug when data length is 1 the bar will hidden
                    */
-                  barSize={data.length === 1 ? 20 : undefined}
+                  barSize={this.singleBarSize}
                 />
               ))}
 
@@ -199,6 +222,7 @@ export default class ComposeCustomChart extends React.PureComponent {
     const tickCount = this.getTickCount()
     const ticks = this.getTicks(tickCount)
     const tickFormatter = this.getTickFormatter(tickCount)
+    const padding = this.XAxisShouldPadding ? barPadding : 0
 
     return (
       <XAxis
@@ -211,6 +235,8 @@ export default class ComposeCustomChart extends React.PureComponent {
         domain={domain}
         ticks={ticks}
         tickFormatter={tickFormatter}
+        allowDataOverflow="false"
+        padding={{ left: padding, right: padding }}
       />
     )
   }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

This problem is caused by the bar interval being bigger than the data interval, the response data just has one and its position is at the first of the response data, so the bar will be out of the boundary.

So, if the response data is just one and it is at the start or tail of xAxis, we will add padding for xAxis and adjust the width of the bar to avoid this problem.

### Which issue(s) this PR fixes:
Fixes ##3118

### Special notes for reviewers:

![截屏2022-04-20 13 58 01](https://user-images.githubusercontent.com/33231138/164161619-f3cf9489-0c5f-46b3-bfb2-7d4264e34a05.png)

![截屏2022-04-20 14 05 10](https://user-images.githubusercontent.com/33231138/164161641-69bb0977-e97d-4a97-88ee-428c4e3681be.png)

### Does this PR introduced a user-facing change?
```release-note
Bars of a custom monitoring dashboard exceed the boundary
```

### Additional documentation, usage docs, etc.: