### PR TITLE
fix: User still can create a volume from a snapshot after its snapshot class has been deleted

### DIFF
--- a/src/stores/volumeSnapshotClasses.js
+++ b/src/stores/volumeSnapshotClasses.js
@@ -52,7 +52,7 @@ export default class VolumeSnapshotClassStore extends Base {
       {},
       () => {}
     )
-    const detail = { ...params, ...this.mapper(result) }
+    const detail = result ? { ...params, ...this.mapper(result) } : {}
 
     this.detail = detail
     this.isLoading = false


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #[#4808](https://github.com/kubesphere/kubesphere/issues/4808)

### Special notes for reviewers:

User cant create a volume from snapshot if its snapshotclass has been deleted.

![截屏2022-04-21 15 47 23](https://user-images.githubusercontent.com/33231138/164405753-89979e62-b0a3-4f9b-a648-34732003daea.png)


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: