### PR TITLE
fix: User still can create a snapshot while selected volume's storageclass has been deleted

### DIFF
--- a/src/pages/projects/components/Modals/ResourceSnapshot/index.jsx
+++ b/src/pages/projects/components/Modals/ResourceSnapshot/index.jsx
@@ -200,17 +200,22 @@ export default class ResourceSnapshot extends React.Component {
     const { volumeInfo } = this.state
     const { storageClassName } = volumeInfo
 
-    await this.storageclass.fetchDetail({
-      cluster,
-      namespace,
-      name: storageClassName,
-    })
+    let allowSnapshot
 
-    const allowSnapshot = get(
-      toJS(this.storageclass).detail.annotations,
-      'storageclass.kubesphere.io/allow-snapshot',
-      'false'
-    )
+    try {
+      await this.storageclass.fetchDetail({
+        cluster,
+        namespace,
+        name: storageClassName,
+      })
+      allowSnapshot = get(
+        toJS(this.storageclass).detail.annotations,
+        'storageclass.kubesphere.io/allow-snapshot',
+        'false'
+      )
+    } catch (err) {
+      allowSnapshot = 'false'
+    }
 
     this.setState(
       {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes:
- User still can create a snapshot while selected volume's storageclass has been deleted
- Update the method that get the snapshotclass

### Special notes for reviewers:

Now, it will disallow user to create it

![截屏2022-04-21 15 59 55](https://user-images.githubusercontent.com/33231138/164408085-a89db5e2-ad14-4fc8-944c-2d36f3c9c3f2.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: