### PR TITLE
fix: Delete a storageclass with 404 warning

### DIFF
--- a/src/actions/storageclass.js
+++ b/src/actions/storageclass.js
@@ -209,7 +209,7 @@ export default {
           // disable it's accessor
           selectNames.forEach(name => {
             updateAccessor.push(
-              accessorStore.patch(
+              accessorStore.silentPatch(
                 { name: `${name}-accessor` },
                 {
                   spec: { storageClassName: `${name}-accessor-disabled` },
@@ -239,12 +239,13 @@ export default {
     on({ store, detail, success, accessorStore, ...props }) {
       const modal = Modal.open({
         onOk: async () => {
-          await accessorStore.patch(
+          await accessorStore.silentPatch(
             { name: `${detail.name}-accessor` },
             {
               spec: { storageClassName: `${detail.name}-accessor-disabled` },
             }
           )
+
           store.delete(detail).then(() => {
             Modal.close(modal)
             Notify.success({ content: t('DELETE_SUCCESSFUL') })

--- a/src/stores/accessor.js
+++ b/src/stores/accessor.js
@@ -31,4 +31,21 @@ export default class accessorStore extends Base {
     this.isLoading = false
     return result
   }
+
+  @action
+  silentPatch(params, newObject) {
+    return this.submitting(
+      request.patch(
+        this.getDetailUrl(params),
+        newObject,
+        {},
+        (err, response) => {
+          if (err) {
+            return err
+          }
+          return response
+        }
+      )
+    )
+  }
 }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

If user cluster lack of accosser related resource, here will create a 404 warning when user delete a storagclass.

![截屏2022-04-21 16 13 58](https://user-images.githubusercontent.com/33231138/164410747-44a82384-defe-406c-a5c9-734e1f65cfef.png)

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?

```release-note
NONE
```

### Additional documentation, usage docs, etc.: