### PR TITLE
feat: Support the grafana dashboard at the namespace

### DIFF
--- a/src/components/Forms/Dashboard/BaseInfo/index.jsx
+++ b/src/components/Forms/Dashboard/BaseInfo/index.jsx
@@ -48,19 +48,14 @@ export default class BaseInfo extends React.Component {
     return get(formTemplate, MODULE_KIND_MAP[module], formTemplate)
   }
 
-  templateSettingsOpts = Object.entries(this.templateSettings)
-    .map(([key, configs]) => ({
+  templateSettingsOpts = Object.entries(this.templateSettings).map(
+    ([key, configs]) => ({
       value: key,
       image: configs.logo,
       label: configs.name === 'Custom' ? t('CUSTOM') : configs.name,
       description: configs.description,
-    }))
-    .filter(item => {
-      if (this.props.module === 'dashboards') {
-        return item.label !== 'Grafana'
-      }
-      return true
     })
+  )
 
   nameValidator = (rule, value, callback) => {
     if (!value) {

--- a/src/stores/dashboard.js
+++ b/src/stores/dashboard.js
@@ -15,9 +15,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
-
+import { action } from 'mobx'
 import Base from 'stores/base'
 
 export default class DashboardStore extends Base {
   module = 'dashboards'
+
+  @action
+  createGrafana(data, params = {}) {
+    return this.submitting(
+      request.post(
+        `/kapis/monitoring.kubesphere.io/v1alpha3/${this.getPath(
+          params
+        )}/dashboards/${data.grafanaDashboardName}/template`,
+        data
+      )
+    )
+  }
 }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes #[#4822](https://github.com/kubesphere/kubesphere/issues/4822)

### Special notes for reviewers:

The create path is: `/kapis/clusters/host/monitoring.kubesphere.io/v1alpha3/namespaces/lcj-grafana/dashboards/test/template`

![截屏2022-04-25 17 55 48](https://user-images.githubusercontent.com/33231138/165066307-6b21b55b-26e1-448c-9ed0-8af24a9f4733.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
