### PR TITLE
fix: Optimize the ui

### DIFF
--- a/src/actions/pipeline.js
+++ b/src/actions/pipeline.js
@@ -82,7 +82,6 @@ export default {
           success && success()
         },
         store,
-        ...props,
         module,
         cluster,
         devops,

--- a/src/components/Forms/Pipelines/PipelineTemplate/index.scss
+++ b/src/components/Forms/Pipelines/PipelineTemplate/index.scss
@@ -1,3 +1,3 @@
 .pipeline_template_form {
-  padding: 0 32px;
+  padding: 0 20px;
 }

--- a/src/components/Forms/Pipelines/PipelineTemplateParams/index.jsx
+++ b/src/components/Forms/Pipelines/PipelineTemplateParams/index.jsx
@@ -91,7 +91,7 @@ export default function PipelineTemplateParams({
               <div className={styles.params}>
                 <Form data={formTemplate} ref={formRef}>
                   {isArray(params) && params.length > 0 ? (
-                    <div>
+                    <div className={styles.params_container}>
                       {params.map((item, index) => (
                         <ParmasItem key={index} option={item} />
                       ))}

--- a/src/components/Forms/Pipelines/PipelineTemplateParams/index.scss
+++ b/src/components/Forms/Pipelines/PipelineTemplateParams/index.scss
@@ -12,16 +12,22 @@
 
   .params {
     min-height: 400px;
-
     border: 1px solid #ccd3db;
-    padding: 10px;
     background: #fff;
     position: relative;
   }
 }
-
-.itemWrapper {
-  margin-bottom: 20px;
+.params_container {
+  padding: 12px;
+  .itemWrapper {
+    display: inline-block;
+    width: 48.8%;
+    margin-bottom: 12px;
+    margin-right: 20px;
+    &:nth-child(2n) {
+      margin-right: 0;
+    }
+  }
 }
 
 .content {

--- a/src/pages/devops/components/Pipeline/PipelineTemplate/index.scss
+++ b/src/pages/devops/components/Pipeline/PipelineTemplate/index.scss
@@ -11,33 +11,31 @@
     margin-bottom: 40px;
   }
 
-  .template {
-    display: flex;
-    flex-wrap: wrap;
-  }
-
   .card {
-    width: 24%;
+    width: 298px;
     height: 184px;
     padding: 20px;
-    margin: 0 1% 1% 0;
-    border: 1px solid transparent;
+    margin: 0 12px 12px 0;
+    border: 1px solid $light-color06;
     border-radius: 4px;
-    box-shadow: 0 8px 16px 0 rgba(36, 46, 66, 0.2);
     background: #ffffff;
     cursor: pointer;
     transition: all 0.2s ease;
     overflow: hidden;
+    box-sizing: border-box;
+    display: inline-block;
 
     &Selected {
       border: 1px solid $dark-color01;
+      box-shadow: 0px 4px 8px rgba(36, 46, 66, 0.2);
     }
 
     &:hover {
       border: 1px solid $dark-color01;
+      box-shadow: 0px 4px 8px rgba(36, 46, 66, 0.2);
     }
 
-    &:last-child {
+    &:nth-child(3n) {
       margin-right: 0;
     }
 

--- a/src/pages/devops/containers/CD/Components/ChartCard/index.jsx
+++ b/src/pages/devops/containers/CD/Components/ChartCard/index.jsx
@@ -59,7 +59,7 @@ export default function ChartCard({ click, item, type, filters }) {
           width={64}
           height={64}
           innerRadius="75%"
-          outerRadius="120%"
+          outerRadius="115%"
           data={[
             {
               name: 'Used',

--- a/src/pages/devops/containers/CD/Components/ChartCard/index.scss
+++ b/src/pages/devops/containers/CD/Components/ChartCard/index.scss
@@ -56,8 +56,8 @@
       }
       &::after {
         width: 5px;
-        height: 4px;
-        top: 6px;
+        height: 5px;
+        top: 5px;
         left: 3px;
       }
 

--- a/src/pages/devops/containers/Pipelines/Detail/PipeLine/index.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/PipeLine/index.jsx
@@ -63,8 +63,8 @@ export default class Pipeline extends React.Component {
       title: t('CREATE_PIPELINE'),
       imageIcon: '/assets/pipeline/pipeline-icon-dark.svg',
       description: t('CREATE_PIPELINE_DESC'),
-      width: '1400px',
-      contentWidth: '1400px',
+      width: '960px',
+      contentWidth: '960px',
       noCodeEdit: true,
       params,
       success: jenkinsFile => {


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind design

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
![image](https://user-images.githubusercontent.com/17872673/166870791-1d97c863-b132-4cea-950d-81cc58c5c332.png)

![image](https://user-images.githubusercontent.com/17872673/166870802-fd0b1aaa-3f95-4e83-b662-cd42aae3a76f.png)

![image](https://user-images.githubusercontent.com/17872673/166870816-bbbdebb1-0dd1-4ed5-987f-4412cfb9d63d.png)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
