### PR TITLE
fix: Update storagecontent table icon when list data is empty

### DIFF
--- a/src/pages/clusters/containers/Storage/VolumeSnapshots/index.jsx
+++ b/src/pages/clusters/containers/Storage/VolumeSnapshots/index.jsx
@@ -48,6 +48,7 @@ export default class VolumesSnapshots extends React.Component {
       description: t('VOLUME_SNAPSHOT_DESC'),
       module: 'VOLUME_SNAPSHOT',
       title: t('VOLUME_SNAPSHOT_PL'),
+      icon: 'snapshot',
     }
   }
 
@@ -65,7 +66,7 @@ export default class VolumesSnapshots extends React.Component {
   }
 
   renderBanner() {
-    if (this.store.ksVersion >= 3.0) {
+    if (this.store.ksVersion >= 3.3) {
       return (
         <Banner {...this.bannerProps} tips={this.tips} routes={this.routes} />
       )

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -268,6 +268,7 @@ export const ICON_TYPES = {
   s2ibuilders: 'vnas',
   apps: 'appcenter',
   'volume-snapshots': 'snapshot',
+  'volume-snapshot-content': 'snapshot',
   customresourcedefinitions: 'select',
   network: 'eip-group',
   networkpolicies: 'firewall',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

![截屏2022-05-09 15 24 11](https://user-images.githubusercontent.com/33231138/167360644-044b8895-b69a-4b6a-8038-c295b9b7709e.png)

![截屏2022-05-09 15 24 33](https://user-images.githubusercontent.com/33231138/167360659-5069fc89-a0ff-4f65-9a99-36cc188ec06b.png)

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
