### PR TITLE
fix: when the node stops scheduling, the scheduling operation is not refreshed

### DIFF
--- a/src/pages/clusters/containers/EdgeNodes/index.jsx
+++ b/src/pages/clusters/containers/EdgeNodes/index.jsx
@@ -175,11 +175,7 @@ export default class EdgeNodes extends React.Component {
   }
 
   getUnschedulable = record => {
-    const taints = record.taints
-
-    return taints.some(
-      taint => taint.key === 'node.kubernetes.io/unschedulable'
-    )
+    return !!record?.unschedulable;
   }
 
   getReady = record => {

--- a/src/pages/clusters/containers/Nodes/index.jsx
+++ b/src/pages/clusters/containers/Nodes/index.jsx
@@ -183,11 +183,7 @@ export default class Nodes extends React.Component {
   }
 
   getUnschedulable = record => {
-    const taints = record.taints
-
-    return taints.some(
-      taint => taint.key === 'node.kubernetes.io/unschedulable'
-    )
+    return !!record?.unschedulable;
   }
 
   getReady = record => {


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
On the cluster node page of the host cluster, when the stop scheduling operation of a node is clicked, the state of the node becomes unschedulable, but the operation displayed in the operation column is still stop scheduling. On the contrary, click start scheduling, the operation is not updated in time. 
This may be accidental.

![GIF](https://user-images.githubusercontent.com/6092586/167848054-9f1ae12c-e392-4ef6-b9cf-8af1c79379b7.gif)


### Special notes for reviewers:
/assign @patrick-luoyu

### Does this PR introduced a user-facing change?
```release-note
None
```

