### PR TITLE
PERF: hide table action menu when project is terminating

### DIFF
--- a/src/components/HOCs/withTableActions.js
+++ b/src/components/HOCs/withTableActions.js
@@ -94,8 +94,16 @@ function withTableActions(WrappedComponent) {
       }
     }
 
+    isTerminating = status => {
+      return status && status === 'Terminating'
+    }
+
     renderMore = (field, record) => {
       if (isEmpty(this.enabledItemActions)) {
+        return null
+      }
+
+      if (record && this.isTerminating(record.status)) {
         return null
       }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

If you modify a project which is terminating, you will get a error Message。

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None

### Special notes for reviewers:
```
@24sama 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

![image](https://user-images.githubusercontent.com/14227595/168050774-a92ba6d6-9142-41b9-a00b-9acf9cda9e39.png)


