### PR TITLE
fix: No workspace created in host cluster on the console page of member cluster

### DIFF
--- a/src/stores/workspace.js
+++ b/src/stores/workspace.js
@@ -44,7 +44,11 @@ export default class WorkspaceStore extends Base {
       ? `kapis/resources.kubesphere.io/v1alpha3${this.getPath(params)}/${
           this.module
         }`
-      : `kapis/tenant.kubesphere.io/v1alpha2${this.getPath(params)}/${
+      : globals.clusterRole === 'host'
+      ? `kapis/tenant.kubesphere.io/v1alpha3${this.getPath(
+          params
+        )}/workspacetemplates`
+      : `kapis/tenant.kubesphere.io/v1alpha3${this.getPath(params)}/${
           this.module
         }`
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #[#4610](https://github.com/kubesphere/kubesphere/issues/4610)

### Special notes for reviewers:

The workspace test was create in host cluster:

https://user-images.githubusercontent.com/33231138/168566915-d254b88b-6f61-428f-aafd-ecd042b92767.mov

The workspace list in member cluster:

https://user-images.githubusercontent.com/33231138/168567202-c12d6458-96d9-4cd3-bfcc-8034130ba7ff.mov


### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: