### PR TITLE
fix: Can't connect to conatiner's kubectl

### DIFF
--- a/src/components/Modals/ContianerTerminal/index.jsx
+++ b/src/components/Modals/ContianerTerminal/index.jsx
@@ -86,7 +86,18 @@ export default class ContainerTerminalModal extends React.Component {
       this.container = container
     }
 
+    this.backupUrls = this.store.oldWebsocketUrl()
     this.url = await this.store.kubeWebsocketUrl()
+  }
+
+  switchToBackupUrl = cb => {
+    if (this.backupUrls.length > 0) {
+      this.url = this.backupUrls.slice(-1)
+      this.backupUrls = this.backupUrls.slice(0, -1)
+    } else {
+      this.backupUrls = []
+      cb()
+    }
   }
 
   get clusters() {
@@ -176,7 +187,10 @@ export default class ContainerTerminalModal extends React.Component {
       <div className={styles.kubectl}>
         <div className={styles.terminalWrapper}>
           <div className={classnames(styles.pane, styles.terminal)}>
-            <ContainerTerminal url={this.url} />
+            <ContainerTerminal
+              url={this.url}
+              socketUrlOnError={this.switchToBackupUrl}
+            />
           </div>
         </div>
         <div className={styles.tipWrapper}>{this.renderContainerMsg()}</div>

--- a/src/stores/terminal.js
+++ b/src/stores/terminal.js
@@ -66,7 +66,7 @@ export default class TerminalStore {
 
     return `kapis/terminal.kubesphere.io/v1alpha2${this.getClusterPath({
       cluster,
-    })}/namespaces/${namespace}/pods/${pod}?container=${container}&shell=${shell}`
+    })}/namespaces/${namespace}/pods/${pod}/exec?container=${container}&shell=${shell}`
   }
 
   oldWebsocketUrl() {
@@ -75,7 +75,7 @@ export default class TerminalStore {
     return [
       `kapis/terminal.kubesphere.io/v1alpha2${this.getClusterPath({
         cluster,
-      })}/namespaces/${namespace}/pods/${pod}/exec?container=${container}&shell=${shell}`,
+      })}/namespaces/${namespace}/pods/${pod}?container=${container}&shell=${shell}`,
     ]
   }
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
Fixes #

### Special notes for reviewers:

It will use the webSocket url with '/exec'  first and try the old url without '/exec' after the connection failed.

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: