### PR TITLE
docs: Remove the 'App ID' and 'Category' parameters of app template

### DIFF
--- a/locales/en/l10n-appStoreManagement-appReview-list.js
+++ b/locales/en/l10n-appStoreManagement-appReview-list.js
@@ -22,7 +22,7 @@ module.exports = {
   APP_REVIEW_DESC: 'Review apps to be released to the App Store.',
   // New
   NEW_SUBMIT: 'New',
-  APP_REVIEW_EMPTY_DESC: 'Please create an app template in a workspace and submit the app template for rewview.',
+  APP_REVIEW_EMPTY_DESC: 'Please create an app template in a workspace and submit the app template for review.',
   APP_STATUS_TO_BE_REVIEWED: 'To be reviewed',
   APP_STATUS_PASSED: 'Approved',
   APP_STATUS_SUSPENDED: 'Suspended',

--- a/src/pages/workspaces/containers/Apps/Detail/index.jsx
+++ b/src/pages/workspaces/containers/Apps/Detail/index.jsx
@@ -29,11 +29,7 @@ import { Image } from 'components/Base'
 
 import AppStore from 'stores/openpitrix/app'
 import VersionStore from 'stores/openpitrix/version'
-import {
-  getVersionTypesName,
-  getAppCategoryNames,
-  transferAppStatus,
-} from 'utils/app'
+import { getVersionTypesName, transferAppStatus } from 'utils/app'
 import { getLocalTime } from 'utils'
 
 import routes from './routes'
@@ -146,16 +142,8 @@ export default class RoleDetail extends React.Component {
 
     return [
       {
-        name: t('APP_ID'),
-        value: detail.app_id,
-      },
-      {
         name: t('STATUS'),
         value: transferAppStatus(detail.status),
-      },
-      {
-        name: t('CATEGORY'),
-        value: getAppCategoryNames(get(detail, 'category_set', [])),
       },
       {
         name: t('TYPE'),


### PR DESCRIPTION
Signed-off-by: Patrick-LuoYu patrickluo@yunify.com

## What type of PR is this?
/kind documentation

## What this PR does / why we need it:
Remove the 'App ID' and 'Category' parameters of app template.

## Special notes for reviewers:

/assign @harrisonliu5

Please take a look. Thanks!

## Does this PR introduce a user-facing change?
```release-note
None
```