### PR TITLE
fix: encrypt pwd when pass to backend

### DIFF
--- a/server/middlewares/checkPwd.js
+++ b/server/middlewares/checkPwd.js
@@ -1,0 +1,58 @@
+const convert = require('koa-convert')
+const bodyParser = require('koa-bodyparser')
+const { send_gateway_request } = require('../libs/request')
+const { decryptPassword } = require('../libs/utils')
+
+const parseBody = convert(
+  bodyParser({
+    formLimit: '200kb',
+    jsonLimit: '200kb',
+    bufferLimit: '4mb',
+  })
+)
+
+module.exports = async (ctx, next) => {
+  const url = ctx.url
+  let params = null
+  if (
+    url === '/kapis/iam.kubesphere.io/v1alpha2/users' &&
+    ctx.method === 'POST'
+  ) {
+    await parseBody(ctx, () => {})
+    params = ctx.request.body
+    params.spec.password = decryptPassword(params.spec.password, 'kubesphere')
+  } else if (
+    /^\/kapis\/iam.kubesphere.io\/v1alpha2\/users\/.*\/password$/.test(url) &&
+    ctx.method === 'PUT'
+  ) {
+    await parseBody(ctx, () => {})
+    params = ctx.request.body
+    params.currentPassword = decryptPassword(
+      params.currentPassword,
+      'kubesphere'
+    )
+    params.password = decryptPassword(params.password, 'kubesphere')
+  }
+
+  if (params) {
+    try {
+      const response = await send_gateway_request({
+        method: ctx.method,
+        headers: ctx.headers,
+        url: ctx.url,
+        token: ctx.cookies.get('token'),
+        params,
+      })
+      ctx.status = 200
+      ctx.body = response
+    } catch (err) {
+      ctx.body = {
+        status: err.code,
+        reason: err.statusText,
+        message: err.message,
+      }
+    }
+  } else {
+    return await next()
+  }
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -23,6 +23,7 @@ const bodyParser = require('koa-bodyparser')
 const proxy = require('./middlewares/proxy')
 const checkToken = require('./middlewares/checkToken')
 const checkIfExist = require('./middlewares/checkIfExist')
+const checkPwd = require('./middlewares/checkPwd')
 
 const {
   k8sResourceProxy,
@@ -68,7 +69,7 @@ router
   .get('/harbor/(.*)', parseBody, handleHarborProxy)
   .get('/blank_md', renderMarkdown)
 
-  .all('/(k)?api(s)?/(.*)', checkToken, checkIfExist)
+  .all('/(k)?api(s)?/(.*)', checkToken, checkIfExist, checkPwd)
   .use(proxy('/(k)?api(s)?/(.*)', k8sResourceProxy))
 
   .get('/sample/:app', parseBody, handleSampleData)

--- a/src/core/containers/Login/index.jsx
+++ b/src/core/containers/Login/index.jsx
@@ -32,7 +32,7 @@ import { get } from 'lodash'
 
 import styles from './index.scss'
 
-function encrypt(salt, str) {
+export function encrypt(salt, str) {
   return mix(salt, window.btoa(str))
 }
 

--- a/src/stores/user.js
+++ b/src/stores/user.js
@@ -23,6 +23,7 @@ import { safeParseJSON } from 'utils'
 import ObjectMapper from 'utils/object.mapper'
 import cookie from 'utils/cookie'
 
+import { encrypt } from 'core/containers/Login'
 import Base from './base'
 import List from './base.list'
 
@@ -240,7 +241,11 @@ export default class UsersStore extends Base {
   @action
   async modifyPassword({ name }, data) {
     return this.submitting(
-      request.put(`${this.getDetailUrl({ name })}/password`, data)
+      request.put(`${this.getDetailUrl({ name })}/password`, {
+        ...data,
+        currentPassword: encrypt('kubesphere', data['currentPassword']),
+        password: encrypt('kubesphere', data['password']),
+      })
     )
   }
 
@@ -348,6 +353,17 @@ export default class UsersStore extends Base {
   @action
   async confirm(data) {
     return await this.submitting(request.post(`login/confirm`, data))
+  }
+
+  @action
+  create(data, params = {}) {
+    const pwd = get(data, 'spec.password', '')
+    return this.submitting(
+      request.post(this.getListUrl(params), {
+        ...data,
+        spec: { ...data.spec, password: encrypt('kubesphere', pwd) },
+      })
+    )
   }
 
   @action


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #3324 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
