### PR TITLE
fix: Remove the limit of cpu use in hpa

### DIFF
--- a/src/pages/projects/components/Modals/HPA/index.jsx
+++ b/src/pages/projects/components/Modals/HPA/index.jsx
@@ -166,7 +166,6 @@ export default class HPAModal extends React.Component {
                 name="metadata.annotations.cpuTargetUtilization"
                 interger
                 min={0}
-                max={100}
                 defaultValue=""
                 onChange={this.handleCPUChange}
               />

--- a/src/pages/projects/containers/Services/index.jsx
+++ b/src/pages/projects/containers/Services/index.jsx
@@ -203,7 +203,7 @@ export default class Services extends React.Component {
       },
       {
         title: t('INTERNAL_ACCESS_PL'),
-        dataIndex: 'annotations["kubesphere.io/serviceType"]',
+        dataIndex: 'clusterIP',
         isHideable: true,
         width: '16%',
         render: (_, record) => {


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/qkcp/issues/248

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
