### PR TITLE
fix: Service Account can not use in member-cluster

### DIFF
--- a/src/core/global.js
+++ b/src/core/global.js
@@ -220,11 +220,12 @@ export default class GlobalValue {
   }
 
   getClusterNavs(cluster) {
+    const needRebuild = get(globals, `need_rebuild_${cluster}_nav`, false)
     if (!get(globals.user, `clusterRules[${cluster}]`)) {
       return []
     }
 
-    if (!this._cache_[`cluster_${cluster}_navs`]) {
+    if (!this._cache_[`cluster_${cluster}_navs`] || needRebuild) {
       const navs = []
 
       cloneDeep(globals.config.clusterNavs).forEach(nav => {

--- a/src/pages/clusters/containers/layout.jsx
+++ b/src/pages/clusters/containers/layout.jsx
@@ -17,7 +17,7 @@
  */
 import React, { Component } from 'react'
 import { inject, observer, Provider } from 'mobx-react'
-import { set, pick } from 'lodash'
+import { set, get, pick } from 'lodash'
 
 import { Loading } from '@kube-design/components'
 
@@ -58,6 +58,10 @@ export default class App extends Component {
       }
 
       set(globals, `clusterConfig.${params.cluster}`, this.store.detail.configz)
+
+      if (get(this.store.detail.configz, 'ksVersion') === '') {
+        set(globals, `need_rebuild_${this.cluster}_nav`, true)
+      }
 
       globals.app.cacheHistory(this.props.match.url, {
         type: 'Cluster',

--- a/src/stores/cluster/index.js
+++ b/src/stores/cluster/index.js
@@ -16,7 +16,7 @@
  * along with KubeSphere Console.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { get, cloneDeep } from 'lodash'
+import { get, cloneDeep, set } from 'lodash'
 import { action, observable } from 'mobx'
 
 import { LIST_DEFAULT_ORDER, DEFAULT_CLUSTER } from 'utils/constants'
@@ -217,5 +217,12 @@ export default class ClusterStore extends Base {
         data
       )
     )
+  }
+
+  @action
+  async fetchClusterConfigz({ cluster }) {
+    await this.fetchDetail({ name: cluster })
+    set(globals, `clusterConfig.${cluster}`, this.detail.configz)
+    return get(this.detail.configz, 'ksVersion', '') !== ''
   }
 }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Sometimes, the member cluster's configz will be an empty object when adding a member to the host cluster.

### Which issue(s) this PR fixes:

Fixes ##3334

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
```release-note
NONE
```

### Additional documentation, usage docs, etc.: