### PR TITLE
fix: Users can't just only edit container port

### DIFF
--- a/src/components/Inputs/ContainerPort/index.jsx
+++ b/src/components/Inputs/ContainerPort/index.jsx
@@ -29,6 +29,7 @@ const DEFAULT_PROTOCOL = 'HTTP'
 const getStateFromProps = props => {
   let protocol = DEFAULT_PROTOCOL
   const { name, containerPort } = props.value
+  const { index } = props
   if (!isUndefined(name)) {
     const matchs = name.match(/^(\w+)-(.*)/)
     if (matchs) {
@@ -37,7 +38,7 @@ const getStateFromProps = props => {
   }
 
   return {
-    name: !isUndefined(name) ? name : `${protocol.toLowerCase()}-`,
+    name: !isUndefined(name) ? name : `${protocol.toLowerCase()}-${index}`,
     protocol: PROTOCOLS.some(item => item.value === protocol)
       ? protocol
       : props.value.protocol,
@@ -82,10 +83,11 @@ export default class ContainerPort extends React.Component {
     let name
     const oldName = this.state.name
     const prefix = `${this.state.protocol.toLowerCase()}-`
+    const { index } = this.props
     if (oldName.startsWith(prefix)) {
       name = `${protocol.toLowerCase()}-${oldName.replace(prefix, '')}`
     } else {
-      name = `${protocol.toLowerCase()}-`
+      name = `${protocol.toLowerCase()}-${index}`
     }
 
     this.setState(

--- a/src/components/Inputs/ContainerPort/index.test.js
+++ b/src/components/Inputs/ContainerPort/index.test.js
@@ -52,7 +52,7 @@ it('renders correctly', () => {
 
 it('change correctly', () => {
   const onchangeCb = jest.fn()
-  const wrapper = mount(<ContainerPort onChange={onchangeCb} />)
+  const wrapper = mount(<ContainerPort onChange={onchangeCb} index={0} />)
   const protocol = wrapper.find('Select[name="protocol"]')
   const name = wrapper.find('Input[name="name"]')
   const port = wrapper.find('NumberInput[name="containerPort"]')
@@ -60,14 +60,14 @@ it('change correctly', () => {
   port.prop('onChange')(8080)
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
-    name: 'http-',
+    name: 'http-0',
     protocol: 'TCP',
   })
 
   protocol.prop('onChange')('REDIS')
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
-    name: 'redis-',
+    name: 'redis-0',
     protocol: 'TCP',
   })
 
@@ -81,14 +81,14 @@ it('change correctly', () => {
   protocol.prop('onChange')('REDIS')
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
-    name: 'redis-',
+    name: 'redis-0',
     protocol: 'TCP',
   })
 
   protocol.prop('onChange')('UDP')
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
-    name: 'udp-',
+    name: 'udp-0',
     protocol: 'UDP',
   })
 })

--- a/src/components/Inputs/ContainerServicePort/index.jsx
+++ b/src/components/Inputs/ContainerServicePort/index.jsx
@@ -29,6 +29,7 @@ const DEFAULT_PROTOCOL = 'HTTP'
 const getStateFromProps = props => {
   let protocol = DEFAULT_PROTOCOL
   const { name, containerPort, servicePort } = props.value
+  const { index } = props
   if (!isUndefined(name)) {
     const matchs = name.match(/^(\w+)-(.*)/)
     if (matchs) {
@@ -37,7 +38,7 @@ const getStateFromProps = props => {
   }
 
   return {
-    name: !isUndefined(name) ? name : `${protocol.toLowerCase()}-`,
+    name: !isUndefined(name) ? name : `${protocol.toLowerCase()}-${index}`,
     protocol: PROTOCOLS.some(item => item.value === protocol)
       ? protocol
       : props.value.protocol,
@@ -84,10 +85,11 @@ export default class ServicePort extends React.Component {
     let name
     const oldName = this.state.name
     const prefix = `${this.state.protocol.toLowerCase()}-`
+    const { index } = this.props
     if (oldName.startsWith(prefix)) {
       name = `${protocol.toLowerCase()}-${oldName.replace(prefix, '')}`
     } else {
-      name = `${protocol.toLowerCase()}-`
+      name = `${protocol.toLowerCase()}-${index}`
     }
 
     this.setState(

--- a/src/components/Inputs/ContainerServicePort/index.test.js
+++ b/src/components/Inputs/ContainerServicePort/index.test.js
@@ -68,7 +68,7 @@ it('renders correctly', () => {
 
 it('change correctly', () => {
   const onchangeCb = jest.fn()
-  const wrapper = mount(<ContainerPort onChange={onchangeCb} />)
+  const wrapper = mount(<ContainerPort onChange={onchangeCb} index={0} />)
   const protocol = wrapper.find('Select[name="protocol"]')
   const name = wrapper.find('Input[name="name"]')
   const containerPort = wrapper.find('NumberInput[name="containerPort"]')
@@ -78,7 +78,7 @@ it('change correctly', () => {
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
     servicePort: undefined,
-    name: 'http-',
+    name: 'http-0',
     protocol: 'TCP',
   })
 
@@ -86,7 +86,7 @@ it('change correctly', () => {
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
     servicePort: 18080,
-    name: 'http-',
+    name: 'http-0',
     protocol: 'TCP',
   })
 
@@ -94,7 +94,7 @@ it('change correctly', () => {
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
     servicePort: 18080,
-    name: 'redis-',
+    name: 'redis-0',
     protocol: 'TCP',
   })
 
@@ -110,7 +110,7 @@ it('change correctly', () => {
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
     servicePort: 18080,
-    name: 'redis-',
+    name: 'redis-0',
     protocol: 'TCP',
   })
 
@@ -118,7 +118,7 @@ it('change correctly', () => {
   expect(onchangeCb).toHaveBeenCalledWith({
     containerPort: 8080,
     servicePort: 18080,
-    name: 'udp-',
+    name: 'udp-0',
     protocol: 'UDP',
   })
 })


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[4955](https://github.com/kubesphere/kubesphere/issues/4955)

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/173728546-37e2fb46-53e1-45d9-a7b2-27e2a5f0ffd8.mov


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
