### PR TITLE
fix: Fix the data is incorre when twice update the cluster kubeconfig

### DIFF
--- a/src/actions/cluster.js
+++ b/src/actions/cluster.js
@@ -87,8 +87,12 @@ export default {
     on({ store, detail, cluster, success, ...props }) {
       const modal = Modal.open({
         onOk: async data => {
-          set(data, 'kubeconfig', btoa(data.kubeconfig))
-          await store.updateKubeConfig({ cluster: detail.name, data })
+          const newData = cloneDeep(data)
+          set(newData, 'kubeconfig', window.btoa(newData.kubeconfig))
+          await store.updateKubeConfig({
+            cluster: detail.name,
+            data: newData,
+          })
           Modal.close(modal)
           Notify.success({ content: t('UPDATE_SUCCESSFUL') })
           success && success()
@@ -111,7 +115,7 @@ const handleImport = async (store, data) => {
     unset(postData, 'spec.connection.kubeconfig')
   } else {
     const config = get(postData, 'spec.connection.kubeconfig', '')
-    set(postData, 'spec.connection.kubeconfig', btoa(config))
+    set(postData, 'spec.connection.kubeconfig', window.btoa(config))
     await store.validate(postData)
   }
 

--- a/src/components/Forms/Secret/SecretSettings/DataForm/index.jsx
+++ b/src/components/Forms/Secret/SecretSettings/DataForm/index.jsx
@@ -77,7 +77,7 @@ export default class SecretDataForm extends React.Component {
     form &&
       form.validate(() => {
         const { key, value } = form.getData()
-        onOk({ [trim(key)]: btoa(value) })
+        onOk({ [trim(key)]: window.btoa(value) })
         callback && callback()
       })
   }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/4965

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
