### PR TITLE
fix: Storage class editing automatic extension maximum value does not take effect

### DIFF
--- a/server/views/blank_markdown.html
+++ b/server/views/blank_markdown.html
@@ -226,6 +226,8 @@
     /* border: 1px solid #dfe2e5; */
     text-align: left;
     margin: 0;
+    max-width: 200px;
+
 }
 
 .markdown-body table tr {

--- a/src/components/Modals/StorageclassAutoresizer/index.jsx
+++ b/src/components/Modals/StorageclassAutoresizer/index.jsx
@@ -41,8 +41,6 @@ const sliderSettings = {
   unit: 'Gi',
 }
 
-const NumberReg = /^[0-9]+(\.[0-9]{0,})?/g
-
 @observer
 export default class StorageClassAutoResizerModal extends React.Component {
   static propTypes = {
@@ -99,7 +97,7 @@ export default class StorageClassAutoResizerModal extends React.Component {
   }
 
   NumberEndDot = num => {
-    const getNumber = NumberReg.exec(num) ?? []
+    const getNumber = /^[0-9]+(\.[0-9]{0,})?/g.exec(num) ?? []
     return endsWith(getNumber[0], '.') ? num.split('.').join('') : num
   }
 
@@ -140,7 +138,9 @@ export default class StorageClassAutoResizerModal extends React.Component {
   handleLimitChange = val => {
     const { resize } = this.state
     const { unit } = sliderSettings
-    const value = NumberReg.test(val) ? `${trim(val)}${unit}` : '10000Gi'
+    const value = /^[0-9]+(\.[0-9]{0,})?/g.test(val)
+      ? `${trim(val)}${unit}`
+      : '10000Gi'
     this.setState({
       resize: {
         ...resize,

--- a/src/pages/projects/containers/Services/Topology/Service/index.jsx
+++ b/src/pages/projects/containers/Services/Topology/Service/index.jsx
@@ -80,7 +80,7 @@ export default class Service extends Component {
               </div>
             </div>
             <div className={styles.footer}>
-              {t(internalIP.toUpperCase()) || label}
+              {internalIP ? t(internalIP.toUpperCase()) : label}
             </div>
           </div>
         </foreignObject>

--- a/src/pages/projects/containers/Volumes/Detail/index.jsx
+++ b/src/pages/projects/containers/Volumes/Detail/index.jsx
@@ -77,14 +77,14 @@ export default class VolumeDetail extends React.Component {
     return this.store.detail.isFedManaged
   }
 
-  get allowClone() {
-    return this.getAllowToDo('storageclass.kubesphere.io/allow-clone')
+  get disableClone() {
+    return this.getDisAllowToDo('storageclass.kubesphere.io/allow-clone')
   }
 
-  get allowSnapshot() {
-    const disable = compareVersion(`${this.ksVersion}`, 'v3.3') >= 0
+  get disableSnapshot() {
     return (
-      disable || this.getAllowToDo('storageclass.kubesphere.io/allow-snapshot')
+      compareVersion(`${this.ksVersion}`, 'v3.3') < 0 ||
+      this.getDisAllowToDo('storageclass.kubesphere.io/allow-snapshot')
     )
   }
 
@@ -94,7 +94,7 @@ export default class VolumeDetail extends React.Component {
     return isPending ? true : !value
   }
 
-  getAllowToDo = key => {
+  getDisAllowToDo = key => {
     try {
       const value = toJS(this.storageclass).detail.annotations[key]
       const isPending = this.store.detail.phase === 'Pending'
@@ -148,7 +148,7 @@ export default class VolumeDetail extends React.Component {
       text: t('CLONE'),
       icon: 'copy',
       action: 'create',
-      disabled: this.allowClone,
+      disabled: this.disableClone,
       onClick: () => {
         this.trigger('volume.clone', {})
       },
@@ -159,7 +159,7 @@ export default class VolumeDetail extends React.Component {
       text: t('CREATE_SNAPSHOT'),
       icon: 'copy',
       action: 'create',
-      disabled: this.allowSnapshot,
+      disabled: this.disableSnapshot,
       onClick: () => {
         this.trigger('volume.create.snapshot', {
           detail: this.store.detail,


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3405,###3406

### Special notes for reviewers:
1)
![截屏2022-06-21 18 10 55](https://user-images.githubusercontent.com/33231138/174775468-c70b3b8a-51ce-4a1b-9daf-d43540e196d1.png)

2)
![截屏2022-06-21 18 11 46](https://user-images.githubusercontent.com/33231138/174775719-c796be0a-90ee-4a17-b77b-cc613d607d01.png)

3)
![截屏2022-06-21 18 13 30](https://user-images.githubusercontent.com/33231138/174776046-331b182a-cf49-4081-9388-8acb4e0535f4.png)

4):
![截屏2022-06-21 18 13 30](https://user-images.githubusercontent.com/33231138/174776500-5801aa48-de01-41f7-99f3-f69b6d07fb7a.png)



### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
