### PR TITLE
Setting the hostpath is required when mounting the hostpath storage volume to an application 

### DIFF
--- a/locales/ar/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/ar/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/en/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/en/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -167,6 +167,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/es/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/es/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -19,8 +19,8 @@ module.exports = {
   // Banner
   WORKLOAD_DESC: 'La carga de trabajo suele ser el operador real para acceder al servicio, y también es el operador real en ejecución para aplicaciones del sistema, como la recopilación y supervisión de registros de nodos. Workload es un modelo abstracto para un grupo de Pods.',
   // List
-  DEPLOYMENT_EMPTY_DESC: 'Cree un deployment.',
-  UPDATING: 'Actualización',
+  DEPLOYMENT_EMPTY_DESC: 'Please create a deployment.',
+  UPDATING: 'Updating',
   // List > Edit Information
   // List > Edit YAML
   // List > Delete
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Volumen Temporal',
   VOLUME_NAME: 'Nombre del volumen',
   VOLUME_NAME_EMPTY: 'Por favor introduce el nombre del volumen',
+  HOST_PATH_EMPTY: 'Por favor introduce el ruta del host del volumen',
   CONTAINER_NOT_SELECTED: 'Selecciona al menos un contenedor para montar',
   NOT_MOUNT: 'No montado',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/fr/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/fr/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/hi/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/hi/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/ko/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/ko/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/lt/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/lt/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/pl/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/pl/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Temporary Volume',
   VOLUME_NAME: 'Volume Name',
   VOLUME_NAME_EMPTY: 'Please set a name for the volume.',
+  HOST_PATH_EMPTY: 'Please set a host path for the volume.',
   CONTAINER_NOT_SELECTED: 'Please mount the volume to at least one container.',
   NOT_MOUNT: 'Not mounted',
   HOSTPATH_VOLUME: 'HostPath Volume',

--- a/locales/tc/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/tc/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: '臨時儲存卷',
   VOLUME_NAME: '儲存卷名稱',
   VOLUME_NAME_EMPTY: '請輸入儲存卷名稱',
+  HOST_PATH_EMPTY: '請輸入存儲卷主機路徑',
   CONTAINER_NOT_SELECTED: '請至少選擇一個容器進行掛載',
   NOT_MOUNT: '不掛載',
   HOSTPATH_VOLUME: 'HostPath 儲存卷',

--- a/locales/tr/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/tr/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: 'Geçici Hacim',
   VOLUME_NAME: 'Hacim Adı',
   VOLUME_NAME_EMPTY: 'Lütfen birim için bir ad belirleyin.',
+  HOST_PATH_EMPTY: 'Lütfen birim için Ana bilgisayar yolu belirleyin.',
   CONTAINER_NOT_SELECTED: 'Lütfen birimi en az bir konteynere bağlayın.',
   NOT_MOUNT: 'Bağlanamadı',
   HOSTPATH_VOLUME: 'HostPath Hacmi',

--- a/locales/zh/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
+++ b/locales/zh/l10n-multiclusterProjects-applicationWorkloads-deployments-list.js
@@ -166,6 +166,7 @@ module.exports = {
   TEMPORARY_VOLUME: '临时卷',
   VOLUME_NAME: '卷名称',
   VOLUME_NAME_EMPTY: '请为卷设置名称。',
+  HOST_PATH_EMPTY: '请为卷设置主机路径。',
   CONTAINER_NOT_SELECTED: '请将卷挂载到至少一个容器。',
   NOT_MOUNT: '不挂载',
   HOSTPATH_VOLUME: 'HostPath 卷',

--- a/src/components/Forms/Workload/VolumeSettings/AddHostPath/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/AddHostPath/index.jsx
@@ -116,7 +116,10 @@ export default class AddHostPath extends React.Component {
           >
             <Input name="name" autoFocus={true} maxLength={63} />
           </Form.Item>
-          <Form.Item label={t('HOST_PATH')}>
+          <Form.Item
+            label={t('HOST_PATH')}
+            rules={[{ required: true, message: t('HOST_PATH_EMPTY') }]}
+          >
             <Input name="hostPath.path" />
           </Form.Item>
           <Form.Item rules={[{ validator: this.mountValidator }]}>


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug


### What this PR does / why we need it:
1. During the creation of a homemade application, when the hostpath storage volume type is mounted, an error message(Deployment.apps \"ss-v1\" is invalid: [spec.template.spec.volumes[0].hostPath.path: Required value, spec.template.spec.containers[0].volumeMounts[0].name: Not found: \"test-zhh\"]) is displayed if the hostpath is not specified. If the hostpath is specified, the application is successfully created.
![hostpath_error](https://user-images.githubusercontent.com/6092586/174993074-ee6e5f12-3d69-4699-8136-da6597ceb4c0.gif)

2. On the other hand, I looked up the Kubernetes API documentation(https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) and the host path is a property that must be set .
![image](https://user-images.githubusercontent.com/6092586/174994339-a8ecdf23-351b-49a0-b5aa-663fc4af913e.png)


### Special notes for reviewers:
```
/assign @zheng1
```

### Does this PR introduced a user-facing change?
```release-note
Setting the hostpath is required when mounting the hostpath storage volume to an application 
```

### Additional documentation, usage docs, etc.:
```docs
Setting the hostpath is required when mounting the hostpath storage volume to an application 
```
