### PR TITLE
fix: Path parsing error in windows environment

### DIFF
--- a/scripts/checkRepeat.js
+++ b/scripts/checkRepeat.js
@@ -1,10 +1,11 @@
 const fs = require('fs')
+const path = require('path')
 
 const args = process.argv.slice(2)
 const filePath = args[0].split('locales')
 
-const lang = filePath[1].split('/')[1]
-const fileName = filePath[1].split('/')[2]
+const lang = filePath[1].split(path.sep)[1]
+const fileName = filePath[1].split(path.sep)[2]
 var repeatArr = []
 const files = fs.readdirSync(`locales/${lang}`)
 const allKeyArr = []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
There will be an error in the window environment when adding translation files

![bug](https://user-images.githubusercontent.com/22656592/176623373-b3f44fec-8c8b-4f67-9c0b-55fb2ba01021.png)

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
