### PR TITLE
fix: canary release is invalid, when multiple operating systems are selected

### DIFF
--- a/src/components/Forms/GrayRelease/PolicyConfig/Canary/OSSelect/index.jsx
+++ b/src/components/Forms/GrayRelease/PolicyConfig/Canary/OSSelect/index.jsx
@@ -26,14 +26,14 @@ export default class OSSelect extends React.Component {
       return []
     }
 
-    return props.value.slice(2, props.value.length - 2).split('|')
+    return props.value.slice(3, props.value.length - 3).split('|')
   }
 
   handleChange = value => {
     const { onChange } = this.props
 
     if (!isEmpty(value)) {
-      onChange && onChange(`.*${value.join('|')}.*`)
+      onChange && onChange(`.*(${value.join('|')}).*`)
     } else {
       onChange && onChange('')
     }

--- a/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
+++ b/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
@@ -659,7 +659,7 @@ export default class GatewaySettingModal extends React.Component {
     const os = headers['User-Agent'] || {}
     const osMatchValue = os.regex
       ? os.regex
-          .slice(2, os.regex.length - 2)
+          .slice(3, os.regex.length - 3)
           .split('|')
           .map(item =>
             CANARY_CONTENT[item] ? CANARY_CONTENT[item].label : item


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug


### What this PR does / why we need it:
canary publishing is invalid when multiple operating systems are selected. 

If a separate operating system (Window or MacOS) is selected for grayscale publishing, the traffic can be switched normally. However, if multiple operating systems (Windows and MacOS) are selected, traffic switchover fails. For example, if other systems release version V1, Windows and MacOS release version V2, both systems still use version V1.

in addition, my version is 3.2.1

![image](https://user-images.githubusercontent.com/6092586/177931046-90f9d7b6-873d-4553-897d-6f0c93536bd9.png)
![image](https://user-images.githubusercontent.com/6092586/177931161-8d025144-cd18-47f8-8b85-f57c9ef61399.png)



### Special notes for reviewers:
```
/assign @patrick-luoyu
```

### Does this PR introduced a user-facing change?

```release-note
fix: canary publishing is invalid when multiple operating systems are selected. 
```
