### PR TITLE
fix: Restore source data while reselect and changing back to source type

### DIFF
--- a/src/components/Forms/Pipelines/RepoSelect/subForm.jsx
+++ b/src/components/Forms/Pipelines/RepoSelect/subForm.jsx
@@ -87,39 +87,46 @@ export default class RepoSelectForm extends React.Component {
 
     if (!isEmpty(sourceData)) {
       this.source_type = sourceData.source_type
+      this.restoreSourceData()
+    }
+  }
+
+  restoreSourceData = () => {
+    const { sourceData } = this.props
+    const { source_type } = sourceData
+
+    this.store.formData = {
+      [REPO_KEY_MAP[source_type]]: omitBy(
+        sourceData[REPO_KEY_MAP[source_type]],
+        (value, key) => key && key.startsWith('discover') && isEmpty(value)
+      ),
+    }
+
+    if (has(sourceData, 'credentialId')) {
+      if (source_type === 'github') {
+        this.store.tokenFormData = { credentialId: sourceData.credentialId }
+      }
+
+      if (source_type === 'git') {
+        set(
+          this.store.formData,
+          `${REPO_KEY_MAP[source_type]}.credential_id`,
+          sourceData.credentialId
+        )
+      }
+
+      if (source_type === 'gitlab') {
+        set(this.store.formData, `${REPO_KEY_MAP[source_type]}`, {})
+      }
+    }
+
+    // initial single_svn type in edit
+    if (source_type === 'single_svn') {
       this.store.formData = {
-        [REPO_KEY_MAP[this.source_type]]: omitBy(
-          sourceData[REPO_KEY_MAP[this.source_type]],
-          (value, key) => key && key.startsWith('discover') && isEmpty(value)
-        ),
-      }
-
-      if (has(sourceData, 'credentialId')) {
-        if (this.source_type === 'github') {
-          this.store.tokenFormData = { credentialId: sourceData.credentialId }
-        }
-
-        if (this.source_type === 'git') {
-          set(
-            this.store.formData,
-            `${REPO_KEY_MAP[this.source_type]}.credential_id`,
-            sourceData.credentialId
-          )
-        }
-
-        if (this.source_type === 'gitlab') {
-          set(this.store.formData, `${REPO_KEY_MAP[this.source_type]}`, {})
-        }
-      }
-
-      // initial single_svn type in edit
-      if (this.source_type === 'single_svn') {
-        this.store.formData = {
-          svn_source: {
-            type: 'single_svn',
-            ...this.store.formData.single_svn_source,
-          },
-        }
+        svn_source: {
+          type: 'single_svn',
+          ...this.store.formData.single_svn_source,
+        },
       }
     }
   }
@@ -205,6 +212,7 @@ export default class RepoSelectForm extends React.Component {
   }
 
   handleTypeChange = e => {
+    const { sourceData } = this.props
     const { type } = e.currentTarget.dataset
 
     this.source_type = type
@@ -214,6 +222,10 @@ export default class RepoSelectForm extends React.Component {
     }
 
     this.store.resetStore()
+
+    if (!isEmpty(sourceData) && sourceData.source_type === type) {
+      this.restoreSourceData()
+    }
   }
 
   renderTypes() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/ks-devops/issues/708

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
