### PR TITLE
fix:the associated hpa hasn't been deleted when use the command line to delete the deployment

### DIFF
--- a/src/pages/projects/components/Modals/HPA/index.jsx
+++ b/src/pages/projects/components/Modals/HPA/index.jsx
@@ -84,8 +84,9 @@ export default class HPAModal extends React.Component {
   }
 
   getFormData = () => {
-    const { name, namespace } = this.props.detail
+    const { name, namespace, uid, kind } = this.props.detail
     const detail = toJS(this.store.detail)
+    const apiVersion = 'apps/v1'
 
     const {
       cpuCurrentUtilization,
@@ -104,6 +105,16 @@ export default class HPAModal extends React.Component {
           memoryCurrentValue,
           memoryTargetValue,
         },
+        ownerReferences: [
+          {
+            apiVersion,
+            blockOwnerDeletion: true,
+            controller: true,
+            kind,
+            name,
+            uid,
+          },
+        ],
       },
       spec: {
         scaleTargetRef: {


### PR DESCRIPTION

Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug



### What this PR does / why we need it:
The associated hpa hasn't been deleted when use the command line to delete the deployment.
![hpa删除](https://user-images.githubusercontent.com/6092586/178449587-dbe5f86f-d42d-46e4-8be1-011c7079f6dc.png)



### Special notes for reviewers:
```
/assign @patrick-luoyu
```

### Does this PR introduced a user-facing change?
```release-note
None
```
