### PR TITLE
fix: Display the type of each workload on the app details page

### DIFF
--- a/src/pages/projects/components/Cards/Workloads/Item.jsx
+++ b/src/pages/projects/components/Cards/Workloads/Item.jsx
@@ -72,6 +72,8 @@ export default class WorkloadItem extends React.Component {
       'annotations["deployment.kubernetes.io/revision"]'
     )
 
+    const kind = get(detail, 'module')
+
     return (
       <div className={styles.item}>
         <Text
@@ -83,6 +85,7 @@ export default class WorkloadItem extends React.Component {
           }
           description={this.getDescription(detail)}
         />
+        <Text title={kind ? t(`${kind}`) : '-'} description={t('TYPE')} />
         <Text
           title={<WorkloadStatus data={detail} module={detail.module} />}
           description={t('STATUS')}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[4986](https://github.com/kubesphere/kubesphere/issues/4986)

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
