### PR TITLE
fix: application's updatetime always is current time

### DIFF
--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -835,6 +835,19 @@ const getApplicationWorkloads = item => {
     .map(com => com.name)
 }
 
+const getApplicationUpdateTime = item => {
+  return get(item, 'status.conditions', []).reduce((max, cur = {}) => {
+    const { lastUpdateTime } = cur
+    if (!max) {
+      return lastUpdateTime
+    }
+    if (!lastUpdateTime) {
+      return max
+    }
+    return max > lastUpdateTime ? max : lastUpdateTime
+  }, undefined)
+}
+
 const ApplicationMapper = item => ({
   ...getBaseInfo(item),
   namespace: get(item, 'metadata.namespace'),
@@ -849,6 +862,7 @@ const ApplicationMapper = item => ({
   status: getApplicationStatus(item),
   services: getApplicationServices(item),
   workloads: getApplicationWorkloads(item),
+  updateTime: getApplicationUpdateTime(item),
   _originData: getOriginData(item),
 })
 


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug



### What this PR does / why we need it:
in the application detail page, the updatetime is always the current time. i check the Application CRD, it has not the updatetime attribution. 
![image](https://user-images.githubusercontent.com/6092586/179946904-db06a421-8d45-499c-8fee-ceb5e6907ace.png)

![image](https://user-images.githubusercontent.com/6092586/179946063-988d5fdf-e123-499b-be9d-4c3986c83229.png)


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
fix: hide the updatetime of application
```


