### PR TITLE
fix: Add monitoring items to the custom monitoring panel, and the monitoring indicators display errors

### DIFF
--- a/src/components/Base/Cascader/index.jsx
+++ b/src/components/Base/Cascader/index.jsx
@@ -60,17 +60,18 @@ export default class Cascader extends Component {
     }))
   }
 
-  getOptionsStyle() {
+  getOptionsStyle(options) {
+    const heightItemCount = options.length >= 8 ? 8 : options.length
     const style = {}
     if (this.ref && this.ref.current) {
       const triggerStyle = this.ref.current.getBoundingClientRect()
       if (
         window.innerHeight - triggerStyle.top >
-        252 + 8 + triggerStyle.height
+        heightItemCount * 31.5 + 8 + triggerStyle.height
       ) {
         style.top = triggerStyle.top + triggerStyle.height + 8
       } else {
-        style.top = triggerStyle.top - 8 - 252
+        style.top = triggerStyle.top - 8 - heightItemCount * 31.5
       }
       style.left = triggerStyle.left
     }
@@ -88,7 +89,7 @@ export default class Cascader extends Component {
         </div>
         {isOpen && (
           <Options
-            style={this.getOptionsStyle()}
+            style={this.getOptionsStyle(options)}
             options={options}
             level={0}
             onSelect={this.handleSelect}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug


### What this PR does / why we need it:

The problem caused by the options's top hight incorrect, It will appears when the options length less than 8.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3358

### Special notes for reviewers:

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
