### PR TITLE
fix: Modify the route of the dashboard when another role login in.

### DIFF
--- a/src/components/Forms/Notification/FeiShuForm/index.jsx
+++ b/src/components/Forms/Notification/FeiShuForm/index.jsx
@@ -83,7 +83,6 @@ export default class FeishuForm extends Component {
       <div className={styles.row}>
         <div className={styles.title}>
           <span>{t('RECIPIENT_SETTINGS')}</span>
-          <p className={styles.subtitle}>至少需要配置一项方可接收通知</p>
         </div>
         <div className={styles.item}>
           <Tabs type="button">

--- a/src/pages/console/containers/Dashboard/index.jsx
+++ b/src/pages/console/containers/Dashboard/index.jsx
@@ -34,10 +34,6 @@ class Dashboard extends React.Component {
     super(props)
 
     if (!globals.app.isPlatformAdmin) {
-      if (globals.user.globalrole === 'users-manager') {
-        return this.routing.push(`/access/accounts`)
-      }
-
       if (globals.app.getActions({ module: 'workspaces' }).includes('create')) {
         return this.routing.push(`/access/workspaces`)
       }

--- a/src/pages/settings/containers/Notification/DingTalk/index.jsx
+++ b/src/pages/settings/containers/Notification/DingTalk/index.jsx
@@ -350,7 +350,7 @@ export default class DingTalk extends React.Component {
       )
     }
     await this.fetchData()
-    Notify.success({ content: '操作成功', duration: 1000 })
+    Notify.success({ content: t('UPDATE_SUCCESSFUL'), duration: 1000 })
   }
 
   onFormClose = () => {

--- a/src/pages/settings/containers/Notification/FeiShu/index.jsx
+++ b/src/pages/settings/containers/Notification/FeiShu/index.jsx
@@ -323,7 +323,7 @@ export default class Feishu extends Component {
       )
     }
     await this.fetchData()
-    Notify.success({ content: '操作成功', duration: 1000 })
+    Notify.success({ content: t('UPDATE_SUCCESSFUL'), duration: 1000 })
   }
 
   onFormClose = () => {


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/5029

### Special notes for reviewers:

https://user-images.githubusercontent.com/17872673/181445348-02a7924a-8e40-48a0-b2e1-7b89d2bc1372.mov





### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
