### PR TITLE
fix: traffic allocation fails after taking over traffic in the canary release modal.

### DIFF
--- a/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
+++ b/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
@@ -322,6 +322,8 @@ export default class GatewaySettingModal extends React.Component {
       unset(strategy, `${prefix}.match[0].headers['User-Agent'].regex`)
     }
 
+    unset(strategy, 'spec.governor')
+
     return strategy
   }
 


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
the traffic allocation fails, after a version takes over traffic in the canary release modal. The concrete representation is:
1. the page traffic allocation conflicts with the top prompt
![traffic_bug](https://user-images.githubusercontent.com/6092586/181709803-69e221fb-2ec1-40bf-bd5d-4f6e1de9dede.png)
2. The service version was not changed according to the traffic allocation rules
![trafficbug](https://user-images.githubusercontent.com/6092586/181711302-5ba523fa-f254-4090-999a-b5c26f9e0dd2.gif)


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
fix: the traffic allocation fails, after a version takes over traffic in the canary release modal.
```
