### PR TITLE
fix: Display volume template info in statefulsets setting modal

### DIFF
--- a/src/components/Forms/Workload/VolumeSettings/VolumeTemplateList/Card.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/VolumeTemplateList/Card.jsx
@@ -25,7 +25,7 @@ import { List } from 'components/Base'
 
 import styles from './index.scss'
 
-const Card = ({ volume, onDelete, onEdit }) => {
+const Card = ({ volume, onDelete, onEdit, banEdit = false }) => {
   const handleDelete = () => onDelete(volume.metadata.name)
   const handleEdit = () => onEdit(volume)
 
@@ -69,6 +69,22 @@ const Card = ({ volume, onDelete, onEdit }) => {
       </ul>
     </div>
   )
+
+  if (banEdit) {
+    return (
+      <List.Item
+        icon="storage"
+        title={get(volume, 'metadata.name', '-')}
+        description={`${t('Storage Classs')}: ${get(
+          volume,
+          'spec.storageClassName',
+          '-'
+        )}`}
+        extras={mount}
+        details={details}
+      />
+    )
+  }
 
   return (
     <List.Item

--- a/src/components/Forms/Workload/VolumeSettings/VolumeTemplateList/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/VolumeTemplateList/index.jsx
@@ -35,6 +35,7 @@ export default class VolumeList extends React.Component {
     onChange: PropTypes.func,
     onShowAddVolume: PropTypes.func,
     onShowEdit: PropTypes.func,
+    hideVolumeSetting: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -45,6 +46,7 @@ export default class VolumeList extends React.Component {
     onChange() {},
     onShowAddVolume() {},
     onShowEdit() {},
+    hideVolumeSetting: false,
   }
 
   static contextTypes = {
@@ -144,7 +146,7 @@ export default class VolumeList extends React.Component {
   }
 
   render() {
-    const { className } = this.props
+    const { className, hideVolumeSetting } = this.props
     const formatVolumes = this.getFormattedVolumes()
 
     return (
@@ -158,11 +160,12 @@ export default class VolumeList extends React.Component {
                   key={get(volume, 'metadata.name')}
                   onEdit={this.handleEdit}
                   onDelete={this.handleDelete}
+                  banEdit={hideVolumeSetting}
                 />
               ))}
             </ul>
           )}
-          {this.renderAddVolume()}
+          {!hideVolumeSetting && this.renderAddVolume()}
         </div>
       </div>
     )

--- a/src/components/Forms/Workload/VolumeSettings/index.jsx
+++ b/src/components/Forms/Workload/VolumeSettings/index.jsx
@@ -666,7 +666,7 @@ class VolumeSettings extends React.Component {
           />
         )}
         <div className={styles.volumes}>
-          {isSTS && !hideVolumeSetting && (
+          {isSTS && (
             <Form.Item>
               <VolumeTemplateList
                 prefix={this.prefix}
@@ -676,6 +676,7 @@ class VolumeSettings extends React.Component {
                 onShowEdit={this.showEditVolumeTemplate}
                 collectSavedLog={collectSavedLog}
                 logPath={logPath}
+                hideVolumeSetting={hideVolumeSetting}
               />
             </Form.Item>
           )}


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[#4196](https://github.com/kubesphere/kubesphere/issues/4196)

### Special notes for reviewers:

![截屏2022-08-03 14 52 46](https://user-images.githubusercontent.com/33231138/182543545-2d0a1093-2f05-490d-9b4b-e13ed9b489a5.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
