### PR TITLE
fix: misbehaving when editing or deleting an image of the same name

### DIFF
--- a/locales/ar/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/ar/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,6 +26,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/es/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/es/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Imagen inválida.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No encontré esta imagen',
   CONTAINER_EMPTY_DESC: 'Por favor agregue al menos un contenedor.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/fr/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/fr/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/hi/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/hi/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/ko/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/ko/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/lt/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/lt/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/pl/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/pl/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: 'No Image Found',
   CONTAINER_EMPTY_DESC: 'Please add at least one container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/tc/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/tc/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: '鏡像無效。',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'The name already exists. Container names must be unique, and multiple containers cannot have the same name.',
   NO_IMAGE_FOUND: '沒有找到此鏡像',
   CONTAINER_EMPTY_DESC: '請至少添加一個容器',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',

--- a/locales/tr/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/tr/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: 'Geçersiz resim.',
   INVALID_NAME_DESC: 'Geçersiz isim. Ad yalnızca küçük harfler, sayılar ve kısa çizgiler (-) içerebilir ve küçük harf veya sayı ile başlayıp bitmelidir. Maksimum uzunluk 63 karakterdir.',
+  DUPLICATE_CONTAINER_NAME_DESC: 'Ad geçersiz. Adlar yalnızca küçük harfler, sayılar ve kısa çizgiler (-) içerebilir, küçük harflerle veya sayılarla başlayıp bitmeli ve en fazla 63 karakter uzunluğunda olmalıdır.',
   NO_IMAGE_FOUND: 'Görsel bulunamadı',
   CONTAINER_EMPTY_DESC: 'Lütfen en az bir konteyner ekleyin.',
   QUOTA_UNSET_TIP: 'Kaynak işgali ayarlanmadı',

--- a/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
@@ -25,6 +25,7 @@ module.exports = {
   // List > Create > Pod Settings > Add Container > Container Settings
   INVALID_IMAGE: '镜像无效。',
   INVALID_NAME_DESC: '名称无效。名称只能包含小写字母、数字和连字符（-），必须以小写字母或数字开头和结尾，最长 63 个字符。',
+  DUPLICATE_CONTAINER_NAME_DESC: '名称已存在。容器名称必须是唯一的，多个容器不能重名。',
   NO_IMAGE_FOUND: '没有找到镜像',
   CONTAINER_EMPTY_DESC: '请至少添加一个容器。',
   QUOTA_UNSET_TIP: '资源占用未设置。',

--- a/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerForm/ContainerSetting/index.jsx
@@ -38,6 +38,13 @@ import ImageInput from './ImageInput'
 import styles from './index.scss'
 
 export default class ContainerSetting extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      originName: props.data.name,
+    }
+  }
+
   get defaultResourceLimit() {
     const { limitRange = {} } = this.props
 
@@ -173,6 +180,16 @@ export default class ContainerSetting extends React.Component {
     callback()
   }
 
+  duplicatedNameValidator = (rule, value, callback) => {
+    const containerNames = this.props.containers
+      .map(({ name }) => name)
+      .filter(i => i !== this.state.originName)
+    if (containerNames.includes(value)) {
+      callback({ message: t('DUPLICATE_CONTAINER_NAME_DESC') })
+    }
+    callback()
+  }
+
   renderAdvancedSettings() {
     const {
       defaultContainerType,
@@ -196,6 +213,9 @@ export default class ContainerSetting extends React.Component {
                     message: t('INVALID_NAME_DESC', {
                       message: t('NAME_DESC'),
                     }),
+                  },
+                  {
+                    validator: this.duplicatedNameValidator,
                   },
                 ]}
               >

--- a/src/components/Forms/Workload/ContainerSettings/ContainerForm/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/ContainerForm/index.jsx
@@ -48,6 +48,7 @@ export default class ContaineForm extends React.Component {
     onCancel: PropTypes.func,
     configMaps: PropTypes.array,
     secrets: PropTypes.array,
+    containers: PropTypes.array,
   }
 
   static defaultProps = {
@@ -61,6 +62,7 @@ export default class ContaineForm extends React.Component {
     onCancel() {},
     configMaps: [],
     secrets: [],
+    containers: [],
   }
 
   static childContextTypes = {
@@ -188,6 +190,7 @@ export default class ContaineForm extends React.Component {
       withService,
       supportGpuSelect,
       projectDetail,
+      containers,
     } = this.props
     const { containerType, formData } = this.state
 
@@ -209,6 +212,7 @@ export default class ContaineForm extends React.Component {
             onContainerTypeChange={this.handleContainerTypeChange}
             workspaceQuota={this.props.workspaceQuota}
             supportGpuSelect={supportGpuSelect}
+            containers={containers}
           />
           <Ports withService={containerType !== 'init' ? withService : false} />
           <ImagePullPolicy />

--- a/src/components/Forms/Workload/ContainerSettings/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/index.jsx
@@ -141,6 +141,21 @@ export default class ContainerSetting extends React.Component {
     return projectDetail.clusters.map(cluster => cluster.name)
   }
 
+  get containers() {
+    const containers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.containers`,
+      []
+    )
+    const initContainers = get(
+      this.fedFormTemplate,
+      `${this.prefix}spec.initContainers`,
+      []
+    )
+
+    return concat(containers, initContainers)
+  }
+
   initService() {
     const workloadName = get(this.formTemplate, 'metadata.name')
     let serviceName = get(this.props.formTemplate, 'Service.metadata.name')
@@ -584,6 +599,7 @@ export default class ContainerSetting extends React.Component {
         workspaceQuota={this.workspaceQuota}
         cluster={cluster}
         supportGpuSelect={supportGpuSelect}
+        containers={this.containers}
         {...params}
       />
     )


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug
/kind feature

### What this PR does / why we need it:
1. When a container with the same name is edited, the modified container configuration is always updated to the first container with the same name.
2. When a container with the same name is deleted, all containers with the same name are deleted
![GIF](https://user-images.githubusercontent.com/6092586/182845357-b12d16cf-d5aa-4810-9cf6-b9ba5d2bf40b.gif)


In addition, duplicate container names are not allowed in the kubernetes, So It is necessary to add duplicate name validation to avoid the operation bug of same container name.
![container不允许重名](https://user-images.githubusercontent.com/6092586/182845429-60f7c73c-d862-4ab6-8130-aaa6c5c80810.png)
![image](https://user-images.githubusercontent.com/6092586/182845651-c7a1de74-32be-4cbc-86bc-b7d1559cf1ea.png)




### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
feat: add duplicate name validation to the container name
```
