### PR TITLE
fix: Modify the api of get cluster list in different user login

### DIFF
--- a/src/components/Modals/ContianerTerminal/index.jsx
+++ b/src/components/Modals/ContianerTerminal/index.jsx
@@ -27,8 +27,6 @@ import TerminalStore from 'stores/terminal'
 import { TypeSelect } from 'components/Base'
 import ContainerTerminal from 'components/Terminal'
 import fullscreen from 'components/Modals/FullscreenModal'
-import ClusterStore from 'stores/cluster'
-import { CLUSTER_PROVIDER_ICON } from 'utils/constants'
 
 import { observable } from 'mobx'
 import styles from './index.scss'
@@ -62,8 +60,6 @@ export default class ContainerTerminalModal extends React.Component {
     })
   }
 
-  clusterStore = new ClusterStore()
-
   async componentDidMount() {
     const params = this.props.match.params
     const { cluster, namespace, podName, containerName } = params
@@ -87,18 +83,6 @@ export default class ContainerTerminalModal extends React.Component {
     }
 
     this.url = await this.store.kubeWebsocketUrl()
-  }
-
-  get clusters() {
-    return this.clusterStore.list.data
-      .filter(item => item.isReady)
-      .map(item => ({
-        label: item.name,
-        value: item.name,
-        icon: CLUSTER_PROVIDER_ICON[item.provider] || 'kubernetes',
-        version: get(item, 'configz.ksVersion'),
-        description: item.provider,
-      }))
   }
 
   handleContainerChange = container => {

--- a/src/pages/clusters/containers/Clusters/index.jsx
+++ b/src/pages/clusters/containers/Clusters/index.jsx
@@ -73,7 +73,7 @@ class Clusters extends React.Component {
   }
 
   fetchData = (params = {}) => {
-    this.store.fetchList({
+    this.store.fetchGrantedList({
       ...params,
       limit: 10,
       labelSelector: '!cluster-role.kubesphere.io/host',
@@ -81,7 +81,7 @@ class Clusters extends React.Component {
   }
 
   fetchHostData = (params = {}) => {
-    this.hostStore.fetchList({
+    this.hostStore.fetchGrantedList({
       ...params,
       labelSelector: 'cluster-role.kubesphere.io/host=',
       limit: -1,

--- a/src/pages/workspaces/components/Modals/WorkspaceCreate/ClusterSettings/ClusterSelect/index.jsx
+++ b/src/pages/workspaces/components/Modals/WorkspaceCreate/ClusterSettings/ClusterSelect/index.jsx
@@ -47,9 +47,8 @@ export default class ClusterSettings extends Component {
         limit: -1,
       })
     } else {
-      await this.clusterStore.fetchList({
+      await this.clusterStore.fetchGrantedList({
         limit: -1,
-        from: 'resource',
         labelSelector: 'cluster.kubesphere.io/visibility=public',
       })
     }

--- a/src/pages/workspaces/components/Modals/WorkspaceSelect/index.jsx
+++ b/src/pages/workspaces/components/Modals/WorkspaceSelect/index.jsx
@@ -38,7 +38,7 @@ export default class WorkspaceSelectModal extends React.Component {
   }
 
   componentDidMount() {
-    this.clusterStore.fetchList({ limit: -1 })
+    this.clusterStore.fetchGrantedList({ limit: -1 })
   }
 
   @computed

--- a/src/pages/workspaces/containers/Projects/index.jsx
+++ b/src/pages/workspaces/containers/Projects/index.jsx
@@ -104,9 +104,9 @@ export default class Projects extends React.Component {
 
   getData = async ({ silent, ...params } = {}) => {
     const { store } = this.props
-
     silent && (store.list.silent = true)
     const { cluster } = this.workspaceStore
+
     if (cluster) {
       await store.fetchList({
         cluster,
@@ -115,7 +115,9 @@ export default class Projects extends React.Component {
         labelSelector:
           'kubefed.io/managed!=true, kubesphere.io/kubefed-host-namespace!=true',
       })
+
       const resources = store.list.data.map(item => item.name)
+
       if (resources.length > 0) {
         await this.monitoringStore.fetchMetrics({
           cluster,
@@ -126,6 +128,7 @@ export default class Projects extends React.Component {
         })
       }
     }
+
     store.list.silent = false
   }
 

--- a/src/stores/cluster/index.js
+++ b/src/stores/cluster/index.js
@@ -74,11 +74,43 @@ export default class ClusterStore extends Base {
     let result
     if (!globals.app.isMultiCluster) {
       result = { items: [DEFAULT_CLUSTER] }
-    } else if (
-      from === 'resource' ||
-      globals.app.hasPermission({ module: 'clusters', action: 'view' })
-    ) {
+    } else {
       result = await request.get(this.getResourceUrl({}), params)
+    }
+
+    const data = get(result, 'items', []).map(this.mapper)
+
+    this.list.update({
+      data: more ? [...this.list.data, ...data] : data,
+      total: result.totalItems || result.total_count || data.length || 0,
+      ...params,
+      limit: Number(params.limit) || 10,
+      page: Number(params.page) || 1,
+      isLoading: false,
+      ...(this.list.silent ? {} : { selectedRowKeys: [] }),
+    })
+
+    return data
+  }
+
+  @action
+  async fetchGrantedList({ from, more, ...params } = {}) {
+    this.list.isLoading = true
+
+    if (!params.sortBy && params.ascending === undefined) {
+      params.sortBy = LIST_DEFAULT_ORDER[this.module] || 'createTime'
+    }
+
+    if (params.limit === Infinity || params.limit === -1) {
+      params.limit = -1
+      params.page = 1
+    }
+
+    params.limit = params.limit || 10
+
+    let result
+    if (!globals.app.isMultiCluster) {
+      result = { items: [DEFAULT_CLUSTER] }
     } else {
       result = await request.get(this.getTenantUrl({}), params)
     }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/5059

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Modify the api of get cluster list in different user login
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
