### PR TITLE
fix: inaccurate container missing validation hints

### DIFF
--- a/locales/ar/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/ar/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
@@ -27,7 +27,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/es/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/es/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Imagen inválida.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No encontré esta imagen',
-  CONTAINER_EMPTY_DESC: 'Por favor agregue al menos un contenedor.',
+  CONTAINER_EMPTY_DESC: 'Por favor agregue al menos un contenedor de trabajo',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/fr/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/fr/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/hi/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/hi/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/ko/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/ko/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/lt/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/lt/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/pl/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/pl/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Invalid image.',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: 'No Image Found',
-  CONTAINER_EMPTY_DESC: 'Please add at least one container.',
+  CONTAINER_EMPTY_DESC: 'Please add at least one worker container.',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/tc/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/tc/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: '鏡像無效。',
   INVALID_NAME_DESC: 'Invalid name. The name can contain only lowercase letters, numbers, and hyphens (-), and must start and end with a lowercase letter or number. The maximum length is 63 characters.',
   NO_IMAGE_FOUND: '沒有找到此鏡像',
-  CONTAINER_EMPTY_DESC: '請至少添加一個容器',
+  CONTAINER_EMPTY_DESC: '請至少添加一個工作容器',
   QUOTA_UNSET_TIP: 'Resource occupation is unset',
   QUOTA_OVERCOST_TIP: 'The current resource occupation has exceeded the remaining',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/tr/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/tr/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: 'Geçersiz resim.',
   INVALID_NAME_DESC: 'Geçersiz isim. Ad yalnızca küçük harfler, sayılar ve kısa çizgiler (-) içerebilir ve küçük harf veya sayı ile başlayıp bitmelidir. Maksimum uzunluk 63 karakterdir.',
   NO_IMAGE_FOUND: 'Görsel bulunamadı',
-  CONTAINER_EMPTY_DESC: 'Lütfen en az bir konteyner ekleyin.',
+  CONTAINER_EMPTY_DESC: 'Lütfen en az bir iş konteyneri ekleyin',
   QUOTA_UNSET_TIP: 'Kaynak işgali ayarlanmadı',
   QUOTA_OVERCOST_TIP: 'Mevcut kaynak işgali kalan miktarı aştı',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings

--- a/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
@@ -26,7 +26,7 @@ module.exports = {
   INVALID_IMAGE: '镜像无效。',
   INVALID_NAME_DESC: '名称无效。名称只能包含小写字母、数字和连字符（-），必须以小写字母或数字开头和结尾，最长 63 个字符。',
   NO_IMAGE_FOUND: '没有找到镜像',
-  CONTAINER_EMPTY_DESC: '请至少添加一个容器。',
+  CONTAINER_EMPTY_DESC: '请至少添加一个工作容器。',
   QUOTA_UNSET_TIP: '资源占用未设置。',
   QUOTA_OVERCOST_TIP: '当前的资源占用已超过剩余资源。',
   // List > Create > Pod Settings > Add Container > Container Settings > Environment Settings


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug



### What this PR does / why we need it:
When adding an init container, the prompt "Please add at least one container" is still misleading to the user.
![image](https://user-images.githubusercontent.com/6092586/183618636-0a2ee4d4-e451-4aa2-b5df-135f7a9c1a64.png)


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?

```release-note
fix: correct the container missing validation hints
```

