### PR TITLE
fix: failed to create routing rules in ipv6 and ipv4 dual-stack environment

### DIFF
--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -720,6 +720,10 @@ const GatewayMapper = item => {
     ''
   )
 
+  // get the first ipv4 ingress's ip, because the k8s can't support ipv6's colon
+  const defaultIngressIPV4 = loadBalancerIngress.find(i => !i.ip.includes(':'))
+    ?.ip
+
   return {
     ...getBaseInfo(item),
     namespace: get(item, 'metadata.namespace'), // it's not metadata.namespace
@@ -731,8 +735,7 @@ const GatewayMapper = item => {
     ports: get(item, 'status.service', []),
     loadBalancerIngress: loadBalancerIngress.map(lb => lb.ip || lb.hostname),
     defaultIngress:
-      get(loadBalancerIngress, '[0].ip') ||
-      get(loadBalancerIngress, '[0].hostname'),
+      defaultIngressIPV4 || get(loadBalancerIngress, '[0].hostname'),
     isHostName: !!get(loadBalancerIngress, '[0].hostname'),
     serviceMeshEnable:
       get(


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
In the ipv6 and ipv4 dual-stack environment, the creation of routing rules fails because the K8S ingress host property does not support colons, whereas ipv6 has colons.
![image](https://user-images.githubusercontent.com/6092586/185336869-ddbb5c17-6f7f-44d8-a28d-164922c6fb30.png)



### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
fix: filter the ipv6 address when automatically generate routing rules
```