### PR TITLE
fix: Get snapshotclass api warning

### DIFF
--- a/src/actions/volume.js
+++ b/src/actions/volume.js
@@ -124,12 +124,13 @@ export default {
     },
   },
   'volume.create.snapshot': {
-    on({ store, detail, ...props }) {
+    async on({ store, detail, ...props }) {
       const provisioner = get(
         detail,
         "annotations['volume.beta.kubernetes.io/storage-provisioner']",
         '-'
       )
+      await store.getSnapshotType()
       const options = []
       store.snapshotType.items.forEach(item => {
         if (item.driver === provisioner) {

--- a/src/pages/projects/containers/Volumes/Detail/index.jsx
+++ b/src/pages/projects/containers/Volumes/Detail/index.jsx
@@ -114,7 +114,6 @@ export default class VolumeDetail extends React.Component {
       cluster,
       name: storageClassName,
     })
-    await this.store.getSnapshotType()
     this.ksVersion = await this.store.getKsVersion(params)
   }
 


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3565

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
