### PR TITLE
optimization the image building of kubesphere/console

### DIFF
--- a/build/DockerfileFinal
+++ b/build/DockerfileFinal
@@ -1,0 +1,23 @@
+# Copyright 2021 The KubeSphere Authors. All rights reserved.
+# Use of this source code is governed by an Apache license
+# that can be found in the LICENSE file.
+
+##############
+# Final Image
+##############
+FROM node:12-alpine3.14 as base_os_context
+
+RUN adduser -D -g kubesphere -u 1002 kubesphere && \
+    mkdir -p /opt/kubesphere/console && \
+    chown -R kubesphere:kubesphere /opt/kubesphere/console
+
+WORKDIR /opt/kubesphere/console
+COPY ./out/ /opt/kubesphere/console/
+
+RUN mv dist/server.js server/server.js
+USER kubesphere
+
+EXPOSE 8080
+
+CMD ["npm", "run", "serve"]
+

--- a/hack/docker_build_multiarch.sh
+++ b/hack/docker_build_multiarch.sh
@@ -19,9 +19,29 @@ fi
 # supported platforms
 PLATFORMS=linux/amd64,linux/arm64
 
+#first preimage
+${CONTAINER_CLI} build \
+  -f build/Dockerfile \
+  --target builder
+  -t ks-console-pre:"${TAG}" .
+
+#build preimage
+${CONTAINER_CLI} create \
+  --name predbuild ks-console-pre:
+
+#copy preimage:./out/ ./out/
+${CONTAINER_CLI} cp \
+  predbuild:/out/ ./out/
+
 # shellcheck disable=SC2086 # inteneded splitting of CONTAINER_BUILDER
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --platform ${PLATFORMS} \
   ${PUSH} \
-  -f build/Dockerfile \
+  -f build/DockerfileFinal \
   -t "${REPO}"/ks-console:"${TAG}" .
+
+#delete preimage
+docker rmi ks-console-pre -f
+
+#delete ./out folder
+rm -rf ./out


### PR DESCRIPTION
Signed-off-by: zhoutian <zhoutian@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
we can build the image easily by the PR

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
optimization the image building of kubesphere/console
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
first we build a pre-image to get the file by webpack 
then we can build the final-image to linux/amd64,linux/arm64 easily by copying the file 
finally we can rm the pre-image and the file
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
