### PR TITLE
optimization the image building of KubeSphere/console

### DIFF
--- a/build/Dockerfile.dapper
+++ b/build/Dockerfile.dapper
@@ -1,0 +1,20 @@
+# Copyright 2022 The KubeSphere Authors. All rights reserved.
+# Use of this source code is governed by an Apache license
+# that can be found in the LICENSE file.
+
+FROM node:12-alpine3.14
+
+RUN adduser -D -g kubesphere -u 1002 kubesphere && \
+    mkdir -p /opt/kubesphere/console && \
+    chown -R kubesphere:kubesphere /opt/kubesphere/console
+
+WORKDIR /opt/kubesphere/console
+COPY ./out/ /opt/kubesphere/console/
+
+RUN mv dist/server.js server/server.js
+USER kubesphere
+
+EXPOSE 8080
+
+CMD ["npm", "run", "serve"]
+

--- a/hack/docker_build_multiarch.sh
+++ b/hack/docker_build_multiarch.sh
@@ -19,9 +19,29 @@ fi
 # supported platforms
 PLATFORMS=linux/amd64,linux/arm64
 
+# build the preimage
+docker buildx build -f build/Dockerfile --target builder --load -t ks-console-pre:"${TAG}" .
+
+# create preimage container
+${CONTAINER_CLI} create \
+  --name predbuild ks-console-pre:"${TAG}"
+
+# copy file from preimage container:./out/ ./out/
+${CONTAINER_CLI} cp \
+  predbuild:/out/ ./out/
+
 # shellcheck disable=SC2086 # inteneded splitting of CONTAINER_BUILDER
 ${CONTAINER_CLI} ${CONTAINER_BUILDER} \
   --platform ${PLATFORMS} \
   ${PUSH} \
-  -f build/Dockerfile \
+  -f build/Dockerfile.dapper \
   -t "${REPO}"/ks-console:"${TAG}" .
+
+# delete preimage
+docker rmi ks-console-pre:"${TAG}" -f
+
+# delete prebuild container
+docker rm predbuild
+
+# delete the folder in ./out
+rm -rf ./out


### PR DESCRIPTION
Signed-off-by: zhoutian <zhoutian@yunify.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
we can build image easily by this PR.
when to webpack to get the javascript file,its will cost much time in linux/arm64, so we just get the  javascript file in linux/amd64,and then build the final images in  linux/amd64or linux/arm64.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
optimization the image building of KubeSphere/console
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
first we build the pre-image to get the file by webpacking
then we can build the image of linux/amd64,linux/arm64  by copy the file
finally we will rmi the pre-image and rm the file by webpacking
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
