### PR TITLE
添加readme中的node版本要求以及支持windows下yarn serve的跨平台运行

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following will show you how to build console from source code.
 
 ### Prerequisite
 #### Node.js
-Console is written using Javascript. If you don't have a Node.js development environment, please [set it up](https://nodejs.org/en/download/). The minimum version required is 12.18.
+Console is written using Javascript. If you don't have a Node.js development environment, please [set it up](https://nodejs.org/en/download/). The minimum version required is 12.18.3 but lower than 14.
 
 #### Yarn
 We use [Yarn](https://yarnpkg.com/) to do package management. If you don't have yarn, use the following to install:

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "build:e2e": "webpack -p --config scripts/webpack.e2e.js --display errors-only",
     "test": "jest",
     "test:e2e": "cypress run",
-    "serve": "NODE_ENV=production node server/server.js",
+    "serve": "cross-env NODE_ENV=production node server/server.js",
     "lint": "eslint src/**/*.jsx src/**/*.js",
     "postinstall": "rimraf node_modules/.cache",
     "prebuild": "rimraf dist",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation

### What this PR does / why we need it:
在windows版本yarn serve会因为没有添加cross-env无法运行，node因为node-sass的版本，需要限制在12和13版本中
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # None

### Special notes for reviewers:
``` package.json 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
