### PR TITLE
fix: There is a delete button for project management permissions to view the details of grayscale publishing tasks

### DIFF
--- a/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
+++ b/src/pages/projects/components/Modals/GrayReleaseDetail/index.jsx
@@ -226,6 +226,17 @@ export default class GatewaySettingModal extends React.Component {
     return formData
   }
 
+  get CanDelete() {
+    const { cluster, workspace, project } = this.props.detail
+    return globals.app.hasPermission({
+      cluster,
+      workspace,
+      project,
+      module: 'grayscale-release',
+      action: 'delete',
+    })
+  }
+
   handlePatch = data => {
     const params = toJS(this.store.detail)
     this.store.patch(params, data).then(() => {
@@ -439,7 +450,9 @@ export default class GatewaySettingModal extends React.Component {
             {t('RELEASE_MODE')}: <strong>{t(`${cate.title}_LOW`)}</strong>
           </p>
         </div>
-        <Button onClick={this.handleOffline}>{t('DELETE')}</Button>
+        {this.CanDelete && (
+          <Button onClick={this.handleOffline}>{t('DELETE')}</Button>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##3568

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
