### PR TITLE
fix: Statefulsets and daemonsets do not show rveision record in app d…

### DIFF
--- a/src/pages/projects/components/Cards/Workloads/Item.jsx
+++ b/src/pages/projects/components/Cards/Workloads/Item.jsx
@@ -42,6 +42,11 @@ export default class WorkloadItem extends React.Component {
     detail: {},
   }
 
+  get showRecord() {
+    const kind = get(this.props.detail, 'module')
+    return !['statefulsets', 'daemonsets'].some(item => item === kind)
+  }
+
   getDescription(detail) {
     const { status, reason } = getWorkloadStatus(detail, detail.module)
     if (reason) {
@@ -90,10 +95,12 @@ export default class WorkloadItem extends React.Component {
           title={<WorkloadStatus data={detail} module={detail.module} />}
           description={t('STATUS')}
         />
-        <Text
-          title={version ? `#${version}` : '-'}
-          description={t('REVISION_RECORD')}
-        />
+        {this.showRecord && (
+          <Text
+            title={version ? `#${version}` : '-'}
+            description={t('REVISION_RECORD')}
+          />
+        )}
       </div>
     )
   }


### PR DESCRIPTION
…etails

Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[5155](https://github.com/kubesphere/kubesphere/issues/5155)

### Special notes for reviewers:
```
```
![屏幕截图 2022-09-07 213346](https://user-images.githubusercontent.com/33231138/188892047-6e8c7da0-9d9a-4a54-95a3-deda0525772d.png)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
