### PR TITLE
fix: misbehaving when editing the same name service

### DIFF
--- a/src/components/Forms/Service/BaseInfo/index.jsx
+++ b/src/components/Forms/Service/BaseInfo/index.jsx
@@ -41,6 +41,7 @@ export default class ServiceBaseInfo extends React.Component {
     this.state = {
       showServiceMesh: false,
       selectApp: {},
+      originName: get(props.formTemplate, 'Service.metadata.name'),
     }
 
     this.store = new ServiceStore()
@@ -135,6 +136,13 @@ export default class ServiceBaseInfo extends React.Component {
   nameValidator = (rule, value, callback) => {
     if (!value) {
       return callback()
+    }
+
+    const existNames = Object.keys(this.props.components)?.filter(
+      i => i !== this.state.originName
+    )
+    if (existNames?.includes(value)) {
+      return callback({ message: t('NAME_EXIST_DESC'), field: rule.field })
     }
 
     this.store

--- a/src/pages/projects/components/Modals/CreateApp/Services/index.jsx
+++ b/src/pages/projects/components/Modals/CreateApp/Services/index.jsx
@@ -202,6 +202,7 @@ export default class Services extends React.Component {
         <CreateAppServiceModal
           cluster={cluster}
           namespace={namespace}
+          components={components}
           detail={editData}
           store={this.serviceStore}
           module="services"

--- a/src/pages/projects/components/Modals/CreateAppService/index.jsx
+++ b/src/pages/projects/components/Modals/CreateAppService/index.jsx
@@ -140,6 +140,7 @@ export default class ServiceCreateModal extends React.Component {
       isFederated,
       projectDetail,
       isSubmitting,
+      components,
     } = this.props
 
     let content
@@ -158,7 +159,7 @@ export default class ServiceCreateModal extends React.Component {
 
         steps[0] = {
           ...steps[0],
-          component: withProps(steps[0].component, { noApp: true }),
+          component: withProps(steps[0].component, { noApp: true, components }),
         }
 
         if (isEmpty(detail) && isFederated) {
@@ -225,7 +226,7 @@ export default class ServiceCreateModal extends React.Component {
 
         steps[0] = {
           ...steps[0],
-          component: withProps(steps[0].component, { noApp: true }),
+          component: withProps(steps[0].component, { noApp: true, components }),
         }
 
         if (isFederated && isEmpty(detail)) {


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug
/kind feature


### What this PR does / why we need it:
When a service with the same name is edited, the modified service configuration is always updated to the first service with the same name.
![服务没有重名校验](https://user-images.githubusercontent.com/6092586/189103384-f37e1d9d-bc8c-41ed-9211-e59c4ee3388a.gif)



### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?

```release-note
feat: add duplicate name validation to the service name
```

