### PR TITLE
feat: Change the kind from 'argo-project' to 'argocd'

### DIFF
--- a/src/actions/cd.js
+++ b/src/actions/cd.js
@@ -73,6 +73,7 @@ const handleFormData = ({ data, module }) => {
   }
 
   set(formTemplate, 'metadata', data.metadata)
+  set(formTemplate, 'spec.kind', 'argocd')
   set(formTemplate, 'spec.argoApp.spec', argoApp)
   return formTemplate
 }

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -695,9 +695,6 @@ const getCDTemplate = () => ({
   kind: 'Application',
   apiVersion: 'gitops.kubesphere.io/v1alpha1',
   metadata: {},
-  spec: {
-    kind: 'argo-project',
-  },
 })
 
 const getCodeRepoTemplate = ({ namespace }) => ({


### PR DESCRIPTION
### What type of PR is this?
/kind design

### What this PR does / why we need it:
We use the 
```yaml
apiVersion: gitops.kubesphere.io/v1alpha1
kind: Application
spec:
  kind: argocd
  argoApp:
```
or 
```yaml
apiVersion: gitops.kubesphere.io/v1alpha1
kind: Application
spec:
  kind: fluxcd
  fluxApp:
```
to identify the kind of this application is `argocd` or `fluxcd`.
See also: https://github.com/kubesphere/ks-devops/pull/778

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
