### PR TITLE
fix: Proxy connected clusters should not have an update kubeconfig button

### DIFF
--- a/src/components/Base/List/index.scss
+++ b/src/components/Base/List/index.scss
@@ -68,6 +68,7 @@
 .texts {
   display: flex;
   overflow: hidden;
+  flex: 1;
 }
 
 .text {

--- a/src/pages/clusters/containers/BaseInfo/index.jsx
+++ b/src/pages/clusters/containers/BaseInfo/index.jsx
@@ -154,7 +154,8 @@ export default class Overview extends React.Component {
   }
 
   get enableManageAction() {
-    const { isHost = false } = this.store.detail
+    const { isHost = false, connectionType } = this.store.detail
+    const proxyConnect = connectionType === 'proxy'
     const actions = this.enabledActions
     const option = []
     if (actions.includes('edit') && globals.app.isMultiCluster) {
@@ -165,7 +166,12 @@ export default class Overview extends React.Component {
         text: t('EDIT_INFORMATION'),
       })
     }
-    if (globals.app.isMultiCluster && !isHost && actions.includes('edit')) {
+    if (
+      globals.app.isMultiCluster &&
+      !isHost &&
+      !proxyConnect &&
+      actions.includes('edit')
+    ) {
       option.push({
         actionName: 'cluster.update.kubeconfig',
         icon: 'data',


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[5222](https://github.com/kubesphere/kubesphere/issues/5222)

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
