### PR TITLE
fix: Add app label

### DIFF
--- a/src/components/Forms/Service/BaseInfo/index.jsx
+++ b/src/components/Forms/Service/BaseInfo/index.jsx
@@ -78,12 +78,17 @@ export default class ServiceBaseInfo extends React.Component {
     const { isFederated, noWorkload } = this.props
 
     const labels = get(this.formTemplate, 'metadata.labels', {})
+    labels.app = value.slice(0, 63)
 
     updateLabels(
       isFederated ? get(this.formTemplate, 'spec.template') : this.formTemplate,
       'services',
       labels
     )
+
+    if (isFederated) {
+      set(this.formTemplate, 'metadata.labels.app', value.slice(0, 63))
+    }
 
     if (!noWorkload) {
       this.updateWorkload(value)
@@ -97,6 +102,7 @@ export default class ServiceBaseInfo extends React.Component {
     const workloadName = `${value}-${labels.version}`
     set(formTemplate[this.workloadKind], 'metadata.name', workloadName)
     set(formTemplate[this.workloadKind], 'metadata.namespace', namespace)
+    set(formTemplate[this.workloadKind], 'metadata.labels.app', value)
 
     updateLabels(
       isFederated

--- a/src/components/Forms/Workload/ContainerSettings/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/index.jsx
@@ -472,6 +472,7 @@ export default class ContainerSetting extends React.Component {
     const serivcePrefix = this.props.isFederated ? 'spec.template.' : ''
 
     set(serviceTemplate, `${serivcePrefix}spec.ports`, servicePorts)
+    const labels = get(this.formTemplate, 'metadata.labels', {})
 
     const podLabels = get(
       this.fedFormTemplate,
@@ -479,6 +480,7 @@ export default class ContainerSetting extends React.Component {
       {}
     )
 
+    set(serviceTemplate, 'metadata.labels', labels)
     set(
       serviceTemplate,
       `${serivcePrefix}spec.selector`,


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
