### PR TITLE
fix: Show '-' when duration is negative

### DIFF
--- a/src/pages/devops/containers/Pipelines/Detail/PipelineLogDialog/logItem.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/PipelineLogDialog/logItem.jsx
@@ -107,7 +107,7 @@ export default class LogItem extends React.Component {
           {step.displayName}
           <span className={styles.logitem_status}>
             <span>
-              {step.durationInMillis
+              {step.durationInMillis && step.durationInMillis > 0
                 ? formatUsedTime(step.durationInMillis)
                 : '-'}
             </span>


### PR DESCRIPTION
### What type of PR is this?
/kind bug

### What this PR does / why we need it:
The duration may be negative cause by jenkins.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/ks-devops/issues/826

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
