### PR TITLE
fix: Pods status display is incorrect

### DIFF
--- a/src/utils/status.js
+++ b/src/utils/status.js
@@ -18,6 +18,13 @@
 
 import { get, isUndefined, isEmpty, sortBy, includes } from 'lodash'
 
+const POD_LIFE_CONDITIONS = [
+  'Initialized',
+  'Ready',
+  'ContainersReady',
+  'PodScheduled',
+]
+
 export const getDeployStatus = ({
   hasS2i,
   spec = {},
@@ -266,7 +273,11 @@ export const getPodStatusAndRestartCount = pod => {
       status = 'Running'
     }
 
-    conditions.forEach(item => {
+    const _conditions = conditions.filter(
+      item => POD_LIFE_CONDITIONS.indexOf(item.type) !== -1
+    )
+
+    _conditions.forEach(item => {
       if (status === 'Running') {
         if (
           item.type === 'Unschedulable'


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

If a pod item's conditions object has nother field, such as: { type: 'ContainerDiskPrssuer', status: 'False' }, it's status will be in pending in the table list.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
