### PR TITLE
fix: the update time is always the latest time on the service detail page

### DIFF
--- a/src/pages/projects/containers/Services/Detail/index.jsx
+++ b/src/pages/projects/containers/Services/Detail/index.jsx
@@ -234,10 +234,10 @@ export default class ServiceDetail extends React.Component {
         name: t('CREATION_TIME_TCAP'),
         value: getLocalTime(detail.createTime).format('YYYY-MM-DD HH:mm:ss'),
       },
-      {
+      /* {
         name: t('UPDATE_TIME_TCAP'),
         value: getLocalTime(detail.updateTime).format('YYYY-MM-DD HH:mm:ss'),
-      },
+      }, */
       {
         name: t('CREATOR'),
         value: detail.creator,


### PR DESCRIPTION

Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug


### What this PR does / why we need it:
the update time is always the latest time on the service detail page. And the status has not conditions property to get the update time.
![image](https://user-images.githubusercontent.com/6092586/194695282-7f4fd06f-b596-4b8c-a445-ac3c63ef11df.png)



### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
delete the update time property on the detail page.
```

