### PR TITLE
feat: add creator annotation for pod

### DIFF
--- a/src/pages/projects/containers/Pods/Detail/index.jsx
+++ b/src/pages/projects/containers/Pods/Detail/index.jsx
@@ -152,6 +152,10 @@ export default class PodDetail extends React.Component {
         name: t('CREATION_TIME_TCAP'),
         value: getLocalTime(detail.createTime).format('YYYY-MM-DD HH:mm:ss'),
       },
+      {
+        name: t('CREATOR'),
+        value: detail.creator,
+      },
     ]
   }
 

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -93,6 +93,13 @@ function buildRequest({
         'metadata.annotations["kubesphere.io/creator"]',
         globals.user.username
       )
+      if (get(params, 'spec.template')) {
+        set(
+          params,
+          'spec.template.metadata.annotations["kubesphere.io/creator"]',
+          globals.user.username
+        )
+      }
     }
     request.body = JSON.stringify(params)
   }


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind feature



### What this PR does / why we need it:
add the creator annotation for pod when creating. so that the pod detail page can be consistent with other details pages, such as application/service/workload detail page.


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
add the creator property on the pod detail page
```
