### PR TITLE
fix: Remove slider in resource quota and can set value to 0

### DIFF
--- a/src/components/Inputs/ResourceLimit/index.jsx
+++ b/src/components/Inputs/ResourceLimit/index.jsx
@@ -40,8 +40,6 @@ import {
 
 import { cpuFormat, memoryFormat } from 'utils'
 
-import Slider from './Slider'
-
 import styles from './index.scss'
 
 export default class ResourceLimit extends React.Component {
@@ -106,11 +104,14 @@ export default class ResourceLimit extends React.Component {
     if (formatNum === Infinity) {
       return formatNum
     }
+
     const inputNum = formatNum && isMemory ? formatNum.slice(0, -2) : formatNum
+
     if (inputNum && String(inputNum).endsWith('.')) {
       const number = formatFn(formatNum, unit)
       return `${number}.`
     }
+
     if (inputNum && String(inputNum).endsWith('.0')) {
       const number = formatFn(formatNum, unit)
       return `${number}.0`
@@ -224,11 +225,12 @@ export default class ResourceLimit extends React.Component {
   }
 
   static getDefaultRequestValue(props, key) {
-    return get(
+    const value = get(
       props,
       `value.requests.${key}`,
-      get(props, `defaultValue.requests.${key}`) ?? 0
+      get(props, `defaultValue.requests.${key}`) ?? ''
     )
+    return value
   }
 
   static getDefaultLimitValue(props, key) {
@@ -296,55 +298,12 @@ export default class ResourceLimit extends React.Component {
     return this.state.gpu.type
   }
 
-  getCPUProps() {
-    const { requests, limits } = this.state
-    return {
-      marks: [
-        { value: 0, label: t('NO_REQUEST'), weight: 2 },
-        { value: 0.2, label: 0.2, weight: 2 },
-        { value: 0.5, label: 0.5, weight: 2 },
-        { value: 1, label: 1, weight: 2 },
-        { value: 2, label: 2, weight: 2 },
-        { value: 3, label: 3, weight: 2 },
-        { value: 4, label: 4 },
-        { value: Infinity, label: t('NO_LIMIT') },
-      ],
-      value: [requests.cpu || 0, limits.cpu || Infinity],
-      onChange: this.handleCPUChange,
-      valueFormatter: this.cpuFormatter,
-      ...this.props.cpuProps,
-      unit: this.cpuUnit,
-    }
-  }
-
-  getMemoryProps() {
-    const { requests, limits } = this.state
-    return {
-      marks: [
-        { value: 0, label: t('NO_REQUEST'), weight: 2 },
-        { value: 200, label: 200, weight: 1 },
-        { value: 500, label: 500, weight: 1 },
-        { value: 1000, label: 1000, weight: 2 },
-        { value: 2000, label: 2000, weight: 2 },
-        { value: 4000, label: 4000, weight: 2 },
-        { value: 6000, label: 6000, weight: 1 },
-        { value: 8000, label: 8000 },
-        { value: Infinity, label: t('NO_LIMIT') },
-      ],
-      value: [requests.memory || 0, limits.memory || Infinity],
-      onChange: this.handleMemoryChange,
-      valueFormatter: this.memoryFormatter,
-      ...this.props.memoryProps,
-      unit: this.memoryUnit,
-    }
-  }
-
   getLimit(value) {
     return isFinite(Number(value)) ? value : ''
   }
 
   getRequest(value) {
-    return value === 0 ? '' : value
+    return value === null || value === undefined ? '' : value
   }
 
   checkError = state => {
@@ -427,10 +386,8 @@ export default class ResourceLimit extends React.Component {
       workspaceLimitCheck: wsL,
       gpu,
     } = this.state
-    const { unit: memoryUnit } = this.getMemoryProps()
-    let { unit: cpuUnit } = this.getCPUProps()
-
-    cpuUnit = cpuUnit === 'Core' ? '' : cpuUnit
+    const memoryUnit = this.memoryUnit
+    const cpuUnit = this.cpuUnit === 'Core' ? '' : this.cpuUnit
 
     const errorList = this.getWorkspaceCheckError()
     errorList.length > 0
@@ -438,12 +395,19 @@ export default class ResourceLimit extends React.Component {
       : onError(cpuError || memoryError)
 
     const result = {}
-    if (requests.cpu > 0 && requests.cpu < Infinity) {
+
+    if (requests.cpu !== '' && requests.cpu >= 0 && requests.cpu < Infinity) {
       set(result, 'requests.cpu', `${requests.cpu}${cpuUnit}`)
     }
-    if (requests.memory > 0 && requests.memory < Infinity) {
+
+    if (
+      requests.memory !== '' &&
+      requests.memory >= 0 &&
+      requests.memory < Infinity
+    ) {
       set(result, 'requests.memory', `${requests.memory}${memoryUnit}`)
     }
+
     if (limits.cpu > 0 && limits.cpu < Infinity) {
       set(result, 'limits.cpu', `${limits.cpu}${cpuUnit}`)
     }
@@ -472,7 +436,7 @@ export default class ResourceLimit extends React.Component {
   handleCPUChange = value => {
     this.setState(
       ({ requests, limits }) => ({
-        requests: { ...requests, cpu: value[0] },
+        requests: { ...requests, cpu: value[0] === 0 ? '' : value[0] },
         limits: { ...limits, cpu: value[1] },
       }),
       this.checkAndTrigger
@@ -482,7 +446,7 @@ export default class ResourceLimit extends React.Component {
   handleMemoryChange = value => {
     this.setState(
       ({ requests, limits }) => ({
-        requests: { ...requests, memory: value[0] },
+        requests: { ...requests, memory: value[0] === 0 ? '' : value[0] },
         limits: { ...limits, memory: value[1] },
       }),
       this.checkAndTrigger
@@ -492,7 +456,8 @@ export default class ResourceLimit extends React.Component {
   handleInputChange = (e, value) => {
     let inputNum
     const name = e.target.name
-    if (value === '') {
+
+    if (value === '' || value === undefined) {
       inputNum = ''
     } else {
       const number = /^(([1-9]{1}\d*)|(0{1}))(\.\d{0,2})?$/.exec(value)
@@ -654,16 +619,6 @@ export default class ResourceLimit extends React.Component {
 
     return (
       <div className={styles.wrapper}>
-        <div className={styles.sliderWrapper}>
-          <div>CPU ({this.cpuUnit})</div>
-          <Slider {...this.getCPUProps()} />
-        </div>
-        <div className={styles.sliderWrapper}>
-          <div>
-            {t('MEMORY')} ({this.memoryUnit})
-          </div>
-          <Slider {...this.getMemoryProps()} />
-        </div>
         <div className={styles.inputWrapper}>
           <Columns className="is-gapless">
             <Column>

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -319,7 +319,7 @@ export const composeComponent = (...Components) => props => (
 )
 
 export const cpuFormat = (cpu, unit = 'Core') => {
-  if (isUndefined(cpu) || cpu === null) {
+  if (isUndefined(cpu) || cpu === null || cpu === '') {
     return cpu
   }
 
@@ -341,7 +341,7 @@ export const cpuFormat = (cpu, unit = 'Core') => {
 }
 
 export const memoryFormat = (memory, unit = 'Mi') => {
-  if (isUndefined(memory) || memory === null) {
+  if (isUndefined(memory) || memory === null || memory === '') {
     return memory
   }
 


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/console/issues/3806

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Remove slider in resource quota and can set value to 0
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
