### PR TITLE
fix: The button for cluster visibility not showing when user is not platform admin

### DIFF
--- a/src/pages/clusters/components/Modals/ClusterVisibility/index.jsx
+++ b/src/pages/clusters/components/Modals/ClusterVisibility/index.jsx
@@ -202,16 +202,19 @@ export default class ClusterVisibility extends React.Component {
                     />
                   ))}
                 </div>
-                <div className={styles.footer}>
-                  <Toggle
-                    checked={isPublic}
-                    onChange={this.handlePublicChange}
-                  />
-                  <span>{t('SET_PUBLIC_CLUSTER')}</span>
-                  <Tooltip content={t('CLUSTER_VISIBILITY_A2')}>
-                    <Icon name="information" />
-                  </Tooltip>
-                </div>
+
+                {globals.user.globalrole === 'platform-admin' && (
+                  <div className={styles.footer}>
+                    <Toggle
+                      checked={isPublic}
+                      onChange={this.handlePublicChange}
+                    />
+                    <span>{t('SET_PUBLIC_CLUSTER')}</span>
+                    <Tooltip content={t('CLUSTER_VISIBILITY_A2')}>
+                      <Icon name="information" />
+                    </Tooltip>
+                  </div>
+                )}
               </div>
             </Column>
             <Column>

--- a/src/pages/clusters/containers/Clusters/index.jsx
+++ b/src/pages/clusters/containers/Clusters/index.jsx
@@ -73,7 +73,7 @@ class Clusters extends React.Component {
   }
 
   fetchData = (params = {}) => {
-    this.store.fetchGrantedList({
+    this.store.fetchListByUser({
       ...params,
       limit: 10,
       labelSelector: '!cluster-role.kubesphere.io/host',
@@ -81,7 +81,7 @@ class Clusters extends React.Component {
   }
 
   fetchHostData = (params = {}) => {
-    this.hostStore.fetchGrantedList({
+    this.hostStore.fetchListByUser({
       ...params,
       labelSelector: 'cluster-role.kubesphere.io/host=',
       limit: -1,


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
