### PR TITLE
fix:Updating crd resource on ks-console page loses status information

### DIFF
--- a/src/stores/crd.resource.js
+++ b/src/stores/crd.resource.js
@@ -38,7 +38,7 @@ export default class CRDResourceStore {
   }
 
   get mapper() {
-    return ObjectMapper.default
+    return ObjectMapper.customresourcedefinitionsedit
   }
 
   getPath({ cluster, namespace } = {}) {

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -96,6 +96,23 @@ const DefaultMapper = item => ({
   _originData: getOriginData(item),
 })
 
+const CRDEditMapper = item => {
+  return {
+    ...getBaseInfo(item),
+    namespace: get(item, 'metadata.namespace'),
+    spec: get(item, 'spec'),
+    _originData: omit(item, [
+      'metadata.uid',
+      'metadata.selfLink',
+      'metadata.generation',
+      'metadata.ownerReferences',
+      'metadata.resourceVersion',
+      'metadata.creationTimestamp',
+      'metadata.managedFields',
+    ]),
+  }
+}
+
 const WorkspaceMapper = item => {
   const overrides = get(item, 'spec.overrides', [])
   const template = get(item, 'spec.template', {})
@@ -1455,6 +1472,7 @@ export default {
   dashboards: DashboardMapper,
   clusterdashboards: DashboardMapper,
   customresourcedefinitions: CRDMapper,
+  customresourcedefinitionsedit: CRDEditMapper,
   pipelines: PipelinesMapper,
   networkpolicies: NetworkPoliciesMapper,
   namespacenetworkpolicies: NetworkPoliciesMapper,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
/kind feature

### What this PR does / why we need it:
Updating crd resource on ks-console page loses status information.
When the user modifies the crd through ks-console, it may cause some unexpected problems.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/console/issues/3865

### Does this PR introduced a user-facing change?

```release-note
When editing the crd resource through ks-console, the original status information will be loaded
```

### Before and after the update

before: does not contain `status` information
<img width="612" alt="image" src="https://user-images.githubusercontent.com/13790023/197331341-a6c18f6b-b2fc-4faa-b9fe-efa7679f8e2f.png">


after: contain `status` information
<img width="609" alt="image" src="https://user-images.githubusercontent.com/13790023/197331409-b01b5e8b-989e-4697-97a9-6739ae39e2cd.png">
