### PR TITLE
 fix: Fix workload and service trffic mettic display empty or falsely

### DIFF
--- a/src/components/Graph/Detail/Monitors/ServiceMonitor.jsx
+++ b/src/components/Graph/Detail/Monitors/ServiceMonitor.jsx
@@ -93,7 +93,7 @@ export default class Monitors extends React.Component {
         {
           duration: 1800,
           direction: 'outbound',
-          reporter: 'destination',
+          reporter: 'source',
         }
       ).then(metrics => {
         this.setState({ outMetrics: metrics })

--- a/src/components/Graph/Detail/Monitors/WorkloadMonitor.jsx
+++ b/src/components/Graph/Detail/Monitors/WorkloadMonitor.jsx
@@ -111,7 +111,7 @@ export default class Monitors extends React.Component {
           {
             duration: 1800,
             direction: 'outbound',
-            reporter: 'destination',
+            reporter: 'source',
           }
         )
         .then(metrics => {

--- a/src/stores/application/crd.js
+++ b/src/stores/application/crd.js
@@ -202,7 +202,7 @@ export default class ApplicationStore extends Base {
       step: 20,
       rateInterval: '20s',
       direction: 'inbound',
-      reporter: 'source',
+      reporter: 'destination',
       ...options,
     }
     return request.get(
@@ -221,7 +221,7 @@ export default class ApplicationStore extends Base {
       step: 20,
       rateInterval: '20s',
       direction: 'inbound',
-      reporter: 'source',
+      reporter: 'destination',
       ...options,
     }
     return request.get(


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
the workload inbound traffic metric and the service traffic metric  display empty  in traffic monitor page of app
![image](https://user-images.githubusercontent.com/10116106/198249553-fafb251d-b75e-48bf-b59d-3a1723dc988c.png)
![bug1](https://user-images.githubusercontent.com/10116106/198249675-4e351a94-d73b-4ca2-958f-6fe0bc1e5170.png)

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
/assign @harrisonliu5
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fixed the bug the workload inbound traffic metric and  service traffic metri display empty  in traffic monitor page of app
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
