### PR TITLE
fix: Fix the empty list is displayed incorrectly in detail of workspace member

### DIFF
--- a/src/pages/workspaces/containers/Members/Detail/DevOps/index.jsx
+++ b/src/pages/workspaces/containers/Members/Detail/DevOps/index.jsx
@@ -99,11 +99,13 @@ export default class MemberDevOpsProjects extends React.Component {
 
   handleClusterChange = cluster => {
     this.workspaceStore.selectCluster(cluster)
-    this.getData()
+    this.getData({ filters: { cluster } })
   }
 
   render() {
-    const { data, isLoading, page, limit, total } = toJS(this.devopsStore.list)
+    const { data, isLoading, page, limit, total, filters } = toJS(
+      this.devopsStore.list
+    )
     const pagination = { page, limit, total }
 
     return (
@@ -119,6 +121,7 @@ export default class MemberDevOpsProjects extends React.Component {
           name="DEVOPS_PROJECT"
           hideSearch
           hideCustom
+          filters={filters}
         />
       </Card>
     )

--- a/src/pages/workspaces/containers/Members/Detail/Projects/index.jsx
+++ b/src/pages/workspaces/containers/Members/Detail/Projects/index.jsx
@@ -103,7 +103,9 @@ export default class MemberProjects extends React.Component {
   }
 
   render() {
-    const { data, page, limit, total, isLoading } = toJS(this.projectStore.list)
+    const { data, page, limit, total, isLoading, filters } = toJS(
+      this.projectStore.list
+    )
     const pagination = { page, limit, total }
 
     return (
@@ -119,6 +121,7 @@ export default class MemberProjects extends React.Component {
           name="PROJECT"
           hideSearch
           hideCustom
+          filters={filters}
         />
       </Card>
     )

--- a/src/stores/devops.js
+++ b/src/stores/devops.js
@@ -269,6 +269,7 @@ export default class DevOpsStore extends Base {
     namespace,
     username,
     type,
+    filters,
     ...params
   } = {}) {
     this.list.isLoading = true
@@ -299,6 +300,7 @@ export default class DevOpsStore extends Base {
       data,
       total: result.totalItems || 0,
       ...params,
+      ...filters,
       cluster: globals.app.isMultiCluster ? cluster : undefined,
       limit: Number(params.limit) || 10,
       page: Number(params.page) || 1,


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/console/issues/3880

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fix the empty list is displayed incorrectly in detail of workspace member
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
