### PR TITLE
fix: Fixed the CPU value of the container details that is displayed incorrectly because it has units.

### DIFF
--- a/src/pages/projects/containers/Pods/Containers/Detail.jsx
+++ b/src/pages/projects/containers/Pods/Containers/Detail.jsx
@@ -27,7 +27,6 @@ import { createCenterWindowOpt } from 'utils/dom'
 import ContainerStore from 'stores/container'
 
 import DetailPage from 'projects/containers/Base/Detail'
-
 import getRoutes from './routes'
 
 @observer
@@ -94,11 +93,17 @@ export default class ContainerDetail extends React.Component {
     return (
       resourceType &&
       Object.keys(resourceType)
-        .map(key =>
-          t(`${key.toUpperCase().replace(/[^A-Z]/g, '_')}_VALUE`, {
-            value: resourceType[key],
+        .map(key => {
+          const isCpu = key === 'cpu'
+          const value =
+            isCpu && resourceType[key].endsWith('m')
+              ? parseInt(resourceType[key], 10) / 1000
+              : resourceType[key]
+
+          return t(`${key.toUpperCase().replace(/[^A-Z]/g, '_')}_VALUE`, {
+            value,
           })
-        )
+        })
         .join('/')
     )
   }


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
Before
![image](https://user-images.githubusercontent.com/17872673/197668860-ba292cd8-e7c3-4f0a-bd4a-8da24c6db4b0.png)

After
![image](https://user-images.githubusercontent.com/17872673/197669174-d9572dfd-d816-4901-9999-5e26129be0e7.png)


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
