### PR TITLE
fix: Fix the value encoded of the secret displayed incorrectly on the detail page

### DIFF
--- a/src/pages/fedprojects/containers/Secrets/Detail/SecretDetail/index.jsx
+++ b/src/pages/fedprojects/containers/Secrets/Detail/SecretDetail/index.jsx
@@ -20,8 +20,7 @@ import React from 'react'
 import { observer, inject } from 'mobx-react'
 import { Button, Icon } from '@kube-design/components'
 import { Card } from 'components/Base'
-
-import { safeBtoa } from 'utils/base64'
+import { get } from 'lodash'
 import styles from './index.scss'
 
 @inject('detailStore')
@@ -38,9 +37,14 @@ export default class SecretDetail extends React.Component {
     }
   }
 
-  convert = value => {
+  get originData() {
+    const originData = this.store.detail._originData?.data ?? {}
+    return originData
+  }
+
+  convert = (value, key) => {
     const { showSecret } = this.state
-    return showSecret ? value : safeBtoa(value)
+    return showSecret ? value : get(this.originData, key, '')
   }
 
   changeSecretState = () => {
@@ -54,11 +58,11 @@ export default class SecretDetail extends React.Component {
       <div className={styles.tlsWrapper}>
         <div className={styles.tlsItem}>
           <div className="h6">{t('CREDENTIAL_SI')}</div>
-          <pre>{this.convert(data['tls.crt'])}</pre>
+          <pre>{this.convert(data['tls.crt'], 'tls.crt')}</pre>
         </div>
         <div className={styles.tlsItem}>
           <div className="h6">{t('PRIVATE_KEY_TCAP')}</div>
-          <pre>{this.convert(data['tls.key'])}</pre>
+          <pre>{this.convert(data['tls.key'], 'tls.key')}</pre>
         </div>
       </div>
     )
@@ -86,17 +90,17 @@ export default class SecretDetail extends React.Component {
               </div>
               <ul>
                 <li>
-                  <span>Username:</span>
-                  <span>{this.convert(value.username)}</span>
+                  <span>{t('USERNAME')}:</span>
+                  <span>{this.convert(value.username, 'username')}</span>
                 </li>
                 <li>
-                  <span>Password:</span>
-                  <span>{this.convert(value.password)}</span>
+                  <span>{t('PASSWORD')}:</span>
+                  <span>{this.convert(value.password, 'password')}</span>
                 </li>
                 {value.email && (
                   <li>
-                    <span>Email:</span>
-                    <span>{this.convert(value.email)}</span>
+                    <span>{t('EMAIL')}:</span>
+                    <span>{this.convert(value.email, 'email')}</span>
                   </li>
                 )}
               </ul>
@@ -115,7 +119,7 @@ export default class SecretDetail extends React.Component {
             <li key={key}>
               <span>{key}:</span>
               <span>
-                <pre>{this.convert(value)}</pre>
+                <pre>{this.convert(value, key)}</pre>
               </span>
             </li>
           ))}
@@ -132,7 +136,7 @@ export default class SecretDetail extends React.Component {
             <li key={key}>
               <span>{t(key.toUpperCase())}:</span>
               <span>
-                <pre>{this.convert(value)}</pre>
+                <pre>{this.convert(value, key)}</pre>
               </span>
             </li>
           ))}

--- a/src/pages/projects/containers/Secrets/Detail/SecretDetail/index.jsx
+++ b/src/pages/projects/containers/Secrets/Detail/SecretDetail/index.jsx
@@ -21,8 +21,7 @@ import { observer, inject } from 'mobx-react'
 import { Button, Icon } from '@kube-design/components'
 import { Card } from 'components/Base'
 import Placement from 'projects/components/Cards/Placement'
-import { safeBtoa } from 'utils/base64'
-
+import { get } from 'lodash'
 import styles from './index.scss'
 
 @inject('detailStore')
@@ -39,9 +38,14 @@ export default class SecretDetail extends React.Component {
     }
   }
 
-  convert = value => {
+  get originData() {
+    const originData = this.store.detail._originData?.data ?? {}
+    return originData
+  }
+
+  convert = (value, key) => {
     const { showSecret } = this.state
-    return showSecret ? value : safeBtoa(value)
+    return showSecret ? value : get(this.originData, key, '')
   }
 
   changeSecretState = () => {
@@ -55,11 +59,11 @@ export default class SecretDetail extends React.Component {
       <div className={styles.tlsWrapper}>
         <div className={styles.tlsItem}>
           <div className="h6">{t('CREDENTIAL_SI')}</div>
-          <pre>{this.convert(data['tls.crt'])}</pre>
+          <pre>{this.convert(data['tls.crt'], 'tls.crt')}</pre>
         </div>
         <div className={styles.tlsItem}>
           <div className="h6">{t('PRIVATE_KEY_TCAP')}</div>
-          <pre>{this.convert(data['tls.key'])}</pre>
+          <pre>{this.convert(data['tls.key'], 'tls.key')}</pre>
         </div>
       </div>
     )
@@ -88,16 +92,16 @@ export default class SecretDetail extends React.Component {
               <ul>
                 <li>
                   <span>{t('USERNAME')}:</span>
-                  <span>{this.convert(value.username)}</span>
+                  <span>{this.convert(value.username, 'username')}</span>
                 </li>
                 <li>
                   <span>{t('PASSWORD')}:</span>
-                  <span>{this.convert(value.password)}</span>
+                  <span>{this.convert(value.password, 'password')}</span>
                 </li>
                 {value.email && (
                   <li>
                     <span>{t('EMAIL')}:</span>
-                    <span>{this.convert(value.email)}</span>
+                    <span>{this.convert(value.email, 'email')}</span>
                   </li>
                 )}
               </ul>
@@ -116,7 +120,7 @@ export default class SecretDetail extends React.Component {
             <li key={key}>
               <span>{key}:</span>
               <span>
-                <pre>{this.convert(value)}</pre>
+                <pre>{this.convert(value, key)}</pre>
               </span>
             </li>
           ))}
@@ -133,7 +137,7 @@ export default class SecretDetail extends React.Component {
             <li key={key}>
               <span>{t(key.toUpperCase())}:</span>
               <span>
-                <pre>{this.convert(value)}</pre>
+                <pre>{this.convert(value, key)}</pre>
               </span>
             </li>
           ))}


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
before 
![image](https://user-images.githubusercontent.com/17872673/197965569-34122660-487b-41eb-b3d5-cacc19d12698.png)

after
![image](https://user-images.githubusercontent.com/17872673/197965005-35169244-fd56-484d-8fa5-4f22fd57adcb.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 Fix the value encoded of the secret displayed incorrectly on the detail page
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
