### PR TITLE
fix:port name cant have consecutive hyphens

### DIFF
--- a/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/en/l10n-projects-applicationWorkloads-deployments-list.js
@@ -35,7 +35,7 @@ module.exports = {
   ENVIRONMENT_INVALID_TIP: 'The key of an environment variable can contain only letters, numbers, underscores (_), hyphens (-), and periods (.), and must not start with a number.',
   ENVIRONMENT_CANNOT_BE_EMPTY: 'Please set a key for the environment variable.',
   // List > Create > Pod Settings > Port Settings
-  WORKLOAD_PORT_NAME_DESC: 'The port name can contain only lowercase letters, numbers and hyphens (-), and must start with a lowercase letter and end with a lowercase letter or number. The maximum length is 15 characters.',
+  WORKLOAD_PORT_NAME_DESC: 'The port name can contain only lowercase letters, numbers and hyphens (-), and must start with a lowercase letter and end with a lowercase letter or number, and cannot have consecutive hyphens. The maximum length is 15 characters.',
   // List > Create > Pod Settings > Update Strategy > Rolling Update Settings
   MAX_EXTRA_PODS_DESC: 'Maximum number or percentage of extra pods allowed during the update process.',
   MAX_EXTRA_PODS: 'Maximum Extra Pods',

--- a/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
+++ b/locales/zh/l10n-projects-applicationWorkloads-deployments-list.js
@@ -34,7 +34,7 @@ module.exports = {
   ENVIRONMENT_INVALID_TIP: '环境变量的键只能包含字母、数字、下划线（_）、连字符（-）和句点（.），并且不能以数字开头。',
   ENVIRONMENT_CANNOT_BE_EMPTY: '请设置环境变量的键。',
   // List > Create > Pod Settings > Port Settings
-  WORKLOAD_PORT_NAME_DESC: '名称只能包含小写字母、数字和连字符（-），必须以小写字母开头并以小写字母或数字结尾，最长 15 个字符。',
+  WORKLOAD_PORT_NAME_DESC: '名称只能包含小写字母、数字和连字符（-），必须以小写字母开头并以小写字母或数字结尾，不能有连续的分隔符，最长 15 个字符。',
   // List > Create > Pod Settings > Update Strategy > Rolling Update Settings
   MAX_EXTRA_PODS_DESC: '更新过程中允许的多余容器组副本的最大数量或百分比。',
   MAX_EXTRA_PODS: '最大多余容器组数量',

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -592,7 +592,7 @@ export const PATTERN_LABEL = /(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?/
 export const PATTERN_TAG = /^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$/
 export const PATTERN_PASSWORD = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[^]{8,64}$/
 export const PATTERN_IMAGE = /^\S+$/
-export const PATTERN_PORT_NAME = /^[a-z]([-a-z0-9]*[a-z0-9])?$/
+export const PATTERN_PORT_NAME = /^[a-z](?:-?[a-z0-9]+)*$/
 export const PATTERN_COMPONENT_VERSION = /^[a-z0-9]+$/
 export const PATTERN_PIPELINE_NAME = /[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/
 export const PATTERN_HOST = /^(?=^.{3,255}$)[*a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$/


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>

### What type of PR is this?
/kind bug

### What this PR does / why we need it:
the port name can not have consecutive hyphens in k8s.
![portnameconsecutivepng](https://user-images.githubusercontent.com/6092586/201627328-0260778d-6c46-4fb5-8b26-88225d4d0c6f.png)


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?
```release-note
fix: port name add consecutive hyphens validation
```
