### PR TITLE
fix: npm start command failed to run on window

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "xterm": "3.8.1"
   },
   "scripts": {
-    "start": "concurrently -k --raw 'yarn dev:client' 'yarn dev:server'",
+    "start": "concurrently -k --raw \"yarn dev:client\" \"yarn dev:server\"",
     "build": "yarn build:client && yarn build:server",
     "dev:client": "cross-env NODE_ENV=development webpack-dev-server --config scripts/webpack.dev.js -w",
     "dev:server": "cross-env NODE_ENV=development nodemon -w ./common -w ./server -e js,yaml server/server.js",


### PR DESCRIPTION
Signed-off-by: zhaohuihui <zhaohuihui_yewu@cmss.chinamobile.com>


### What type of PR is this?
/kind bug


### What this PR does / why we need it:
npm start run failed on window.
![window npm start fail](https://user-images.githubusercontent.com/6092586/201890426-3c0aa96c-45e7-47a7-bac4-81b22ab04cbd.png)


### Special notes for reviewers:
```
/assign harrisonliu5
```

### Does this PR introduced a user-facing change?

```release-note
None
```

