### PR TITLE
feat: change helm values Input component to ArrayInput and ObjectInput

### DIFF
--- a/src/actions/fluxcd.js
+++ b/src/actions/fluxcd.js
@@ -58,6 +58,22 @@ const buildHelmRelease = data => {
     }
     return o
   }
+  const arr2Obj = arr => {
+    if (arr === undefined) return null
+    const gen = (idx, arr, end) => {
+      if (idx == arr.length) {
+        return end
+      }
+      return { [arr[idx]]: gen(++idx, arr, end) }
+    }
+
+    let o = {}
+    for (entry of arr) {
+      let ks = entry.k.split('.')
+      o = Object.assign(o, gen(0, ks, entry.v))
+    }
+    return o
+  }
   if (
     data.metadata.labels &&
     data.metadata.labels['gitops.kubesphere.io/save-helm-template']
@@ -96,6 +112,7 @@ const buildHelmRelease = data => {
                     : null,
                 targetNamespace: data.destination.namespace,
               },
+              values: arr2Obj(data.config.helmRelease.values),
               interval: data.config.helmRelease.interval,
               releaseName: data.config.helmRelease.releaseName,
               storageNamespace: data.config.helmRelease.storageNamespace,

--- a/src/actions/fluxcd.js
+++ b/src/actions/fluxcd.js
@@ -22,7 +22,7 @@ import { Modal } from 'components/Base'
 import { Notify } from '@kube-design/components'
 import DeleteModal from 'components/Modals/CDDelete'
 import FORM_TEMPLATES from 'utils/form.templates'
-import { set, isEmpty, cloneDeep, split } from 'lodash'
+import { set, isEmpty, cloneDeep, split, merge } from 'lodash'
 import { toJS } from 'mobx'
 import EditCDAdvanceSetting from 'components/Modals/CDAdvanceEdit'
 
@@ -70,7 +70,7 @@ const buildHelmRelease = data => {
     let o = {}
     for (entry of arr) {
       let ks = entry.k.split('.')
-      o = Object.assign(o, gen(0, ks, entry.v))
+      o = merge(o, gen(0, ks, entry.v))
     }
     return o
   }

--- a/src/components/Forms/CD/FluxCD/Advance/index.jsx
+++ b/src/components/Forms/CD/FluxCD/Advance/index.jsx
@@ -34,6 +34,7 @@ import { FLUXCD_APP_TYPES } from 'utils/constants'
 
 import { TypeSelect } from 'components/Base'
 import { get, set } from 'lodash'
+import { ArrayInput, ObjectInput } from 'components/Inputs'
 import Placement from '../../Advance/Placement'
 import styles from './index.scss'
 
@@ -154,11 +155,21 @@ export default class Advance extends React.Component {
                   <Column>
                     <Form.Item
                       label={t('Values')}
-                      desc={t('Values holds the values for this Helm release.')}
+                      desc={t('Values holds the values for this HelmRelease')}
                     >
-                      <Input name="config.helmRelease.values" />
+                      <ArrayInput
+                        name="config.helmRelease.values"
+                        itemType="object"
+                      >
+                        <ObjectInput>
+                          <Input name="k" placeholder={t('KEY')} />
+                          <Input name="v" placeholder={t('VALUE')} />
+                        </ObjectInput>
+                      </ArrayInput>
                     </Form.Item>
                   </Column>
+                </Columns>
+                <Columns>
                   <Column>
                     <Form.Item
                       label={t('ValuesFrom')}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature


### What this PR does / why we need it:
We need pass raw json values into `config.helmRelease.values` field like below:
```yaml
replicaCount: 6
service: 
  type: LoadBalancer
```
We can use `ArrayInput` and `ObjectInput` components to collect k&v then convert these strings to Object.

Result:

<img width="940" alt="image" src="https://user-images.githubusercontent.com/53958238/202829016-aa7cffae-157d-4d68-b618-7e575dcd5068.png">


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
