### PR TITLE
feat: Add helm valuesFrom

### DIFF
--- a/src/actions/fluxcd.js
+++ b/src/actions/fluxcd.js
@@ -22,7 +22,7 @@ import { Modal } from 'components/Base'
 import { Notify } from '@kube-design/components'
 import DeleteModal from 'components/Modals/CDDelete'
 import FORM_TEMPLATES from 'utils/form.templates'
-import { set, isEmpty, cloneDeep, split, merge } from 'lodash'
+import { set, isEmpty, cloneDeep, split } from 'lodash'
 import { toJS } from 'mobx'
 import EditCDAdvanceSetting from 'components/Modals/CDAdvanceEdit'
 
@@ -58,22 +58,6 @@ const buildHelmRelease = data => {
     }
     return o
   }
-  const arr2Obj = arr => {
-    if (arr === undefined) return null
-    const gen = (idx, arr, end) => {
-      if (idx == arr.length) {
-        return end
-      }
-      return { [arr[idx]]: gen(++idx, arr, end) }
-    }
-
-    let o = {}
-    for (entry of arr) {
-      let ks = entry.k.split('.')
-      o = merge(o, gen(0, ks, entry.v))
-    }
-    return o
-  }
   if (
     data.metadata.labels &&
     data.metadata.labels['gitops.kubesphere.io/save-helm-template']
@@ -97,7 +81,7 @@ const buildHelmRelease = data => {
         helmRelease: {
           chart: {
             chart: data.config.helmRelease.chart.chart,
-            valuesFiles: data.config.helmRelease.chart.valuesFiles,
+            valuesFiles: split(data.config.helmRelease.chart.valuesFiles, ';'),
           },
           deploy: [
             {
@@ -113,6 +97,7 @@ const buildHelmRelease = data => {
                 targetNamespace: data.destination.namespace,
               },
               values: arr2Obj(data.config.helmRelease.values),
+              valuesFrom: data.config.helmRelease.valuesFrom,
               interval: data.config.helmRelease.interval,
               releaseName: data.config.helmRelease.releaseName,
               storageNamespace: data.config.helmRelease.storageNamespace,

--- a/src/components/Forms/CD/FluxCD/Advance/index.jsx
+++ b/src/components/Forms/CD/FluxCD/Advance/index.jsx
@@ -29,6 +29,7 @@ import {
   Menu,
   Collapse,
   Select,
+  Icon,
 } from '@kube-design/components'
 
 import { FLUXCD_APP_TYPES } from 'utils/constants'
@@ -188,18 +189,45 @@ export default class Advance extends React.Component {
                       >
                         <ObjectInput>
                           <Select
+                            name="kind"
+                            defaultValue="ConfigMap"
+                            optionRenderer={option => (
+                              <span className="option-with-icon">
+                                <Icon
+                                  name={option.icon}
+                                  style={{
+                                    marginRight: 6,
+                                    verticalAlign: 'middle',
+                                  }}
+                                  type="light"
+                                />
+                                <span>{option.label}</span>
+                              </span>
+                            )}
+                            valueRenderer={option => (
+                              <span className="option-with-icon">
+                                <Icon
+                                  name={option.icon}
+                                  style={{
+                                    marginRight: 6,
+                                    verticalAlign: 'middle',
+                                  }}
+                                />
+                                <span>{option.value}</span>
+                              </span>
+                            )}
                             options={[
                               {
                                 label: 'ConfigMap',
                                 value: 'ConfigMap',
+                                icon: 'hammer',
                               },
                               {
-                                label: 'Secert',
-                                value: 'Secert',
+                                label: 'Secret',
+                                value: 'Secret',
+                                icon: 'key',
                               },
                             ]}
-                            name="kind"
-                            defaultValue="ConfigMap"
                           />
                           <Input name="name" placeholder={t('NAME')} />
                           <Input

--- a/src/components/Forms/CD/FluxCD/Advance/index.jsx
+++ b/src/components/Forms/CD/FluxCD/Advance/index.jsx
@@ -23,10 +23,7 @@ import {
   Column,
   Columns,
   Toggle,
-  Tag,
   Tabs,
-  Dropdown,
-  Menu,
   Collapse,
   Select,
   Icon,
@@ -36,7 +33,6 @@ import { FLUXCD_APP_TYPES } from 'utils/constants'
 import { ArrayInput, ObjectInput } from 'components/Inputs'
 import { TypeSelect } from 'components/Base'
 import { get, set } from 'lodash'
-import { ArrayInput, ObjectInput } from 'components/Inputs'
 import Placement from '../../Advance/Placement'
 import styles from './index.scss'
 

--- a/src/components/Forms/CD/FluxCD/Advance/index.jsx
+++ b/src/components/Forms/CD/FluxCD/Advance/index.jsx
@@ -28,10 +28,11 @@ import {
   Dropdown,
   Menu,
   Collapse,
+  Select,
 } from '@kube-design/components'
 
 import { FLUXCD_APP_TYPES } from 'utils/constants'
-
+import { ArrayInput, ObjectInput } from 'components/Inputs'
 import { TypeSelect } from 'components/Base'
 import { get, set } from 'lodash'
 import { ArrayInput, ObjectInput } from 'components/Inputs'
@@ -178,27 +179,35 @@ export default class Advance extends React.Component {
                     <Form.Item
                       label={t('ValuesFrom')}
                       desc={
-                        <div>
-                          <Dropdown
-                            content={
-                              <Menu>
-                                <Menu.MenuItem key="ConfigMap">
-                                  ConfigMap
-                                </Menu.MenuItem>
-                                <Menu.MenuItem key="Secret">
-                                  Secret
-                                </Menu.MenuItem>
-                              </Menu>
-                            }
-                          >
-                            <Tag type="primary">ConfigMap</Tag>
-                          </Dropdown>
-                        </div>
+                        'ValuesFrom holds references to resources containing Helm values for this HelmRelease'
                       }
                     >
-                      <div>
-                        <Input name="config.helmRelease.valuesFrom.secret" />
-                      </div>
+                      <ArrayInput
+                        name="config.helmRelease.valuesFrom"
+                        itemType="object"
+                      >
+                        <ObjectInput>
+                          <Select
+                            options={[
+                              {
+                                label: 'ConfigMap',
+                                value: 'ConfigMap',
+                              },
+                              {
+                                label: 'Secert',
+                                value: 'Secert',
+                              },
+                            ]}
+                            name="kind"
+                            defaultValue="ConfigMap"
+                          />
+                          <Input name="name" placeholder={t('NAME')} />
+                          <Input
+                            name="valuesKey"
+                            placeholder={t('ValuesKey')}
+                          />
+                        </ObjectInput>
+                      </ArrayInput>
                     </Form.Item>
                   </Column>
                 </Columns>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature

### What this PR does / why we need it:
The [ValuesFrom](https://fluxcd.io/flux/components/helm/helmreleases/#values-overrides) is a feature provided by FluxCD.

I think we can pass a list of the below Objects by ArrayInput and Object Input Components.
```golang
type ValuesReference struct {
	Kind string `json:"kind"`
	Name string `json:"name"`
	ValuesKey string `json:"valuesKey,omitempty"`
}
```

Result:

<img width="936" alt="image" src="https://user-images.githubusercontent.com/53958238/202837284-bd355eb6-1ad4-4e18-8092-4d02f8b1a0a2.png">


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
