### PR TITLE
fix: Display optimization in code repository

### DIFF
--- a/src/components/Forms/Pipelines/RepoSelect/index.jsx
+++ b/src/components/Forms/Pipelines/RepoSelect/index.jsx
@@ -93,7 +93,7 @@ export default class valueSelect extends React.Component {
             <div className={styles.name}>
               {data.repo || data.url || data.remote}
             </div>
-            <div className={styles.desc}>{data.description || '-'}</div>
+            <div className={styles.desc}>{data.description || ''}</div>
           </div>
           <div className={styles.action}>
             <Button onClick={this.props.onClick}>{t('RESELECT')}</Button>


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[3235](https://github.com/kubesphere/console/issues/3235)

### Special notes for reviewers:

![截屏2023-01-10 14 09 03](https://user-images.githubusercontent.com/33231138/211474989-7fd0e669-0241-4494-8957-f0b690298dfb.png)

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
NONE
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
