### PR TITLE
fix: Gateway does not automatically refresh after a Resource Status change

### DIFF
--- a/src/stores/gateway.js
+++ b/src/stores/gateway.js
@@ -107,6 +107,17 @@ export default class Gateway extends Base {
   }
 
   @action
+  async getGatewayReplica(params) {
+    const url = `${this.gatewayPodsUrl(params)}/pods`
+    const result = await this.submitting(request.get(url))
+    let pods = []
+    if (result && result.totalItems > 0) {
+      pods = result.items.map(item => ObjectMapper.pods(item))
+    }
+    return pods
+  }
+
+  @action
   async getGatewayByProject(params) {
     this.gateway.isLoading = true
     const url = this.gatewayUrl(params)
@@ -196,7 +207,7 @@ export default class Gateway extends Base {
 
     this.logs = {
       data,
-      total: result.query.total || data.length || 0,
+      total: get(result, 'query.total') || data.length || 0,
       ...params,
       size: Number(params.size) || 10,
       from: Number(params.from) || 0,
@@ -284,13 +295,13 @@ export default class Gateway extends Base {
     }))
 
     this.podList.update({
-      data: more ? [...this.list.data, ...data] : data,
+      data: more ? [...this.podList.data, ...data] : data,
       total: result.totalItems || result.total_count || data.length || 0,
       ...params,
       limit: Number(params.limit) || 10,
       page: Number(params.page) || 1,
       isLoading: false,
-      ...(this.list.silent ? {} : { selectedRowKeys: [] }),
+      ...(this.podList.silent ? {} : { selectedRowKeys: [] }),
     })
 
     return []


### PR DESCRIPTION
Signed-off-by: TheYoungManLi <cjl@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes ##[5368](https://github.com/kubesphere/kubesphere/issues/5368)

### Special notes for reviewers:

https://user-images.githubusercontent.com/33231138/212251061-3a5767ad-91ac-4a09-83cd-dd3e31d5f1a4.mov


### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Gateway does not automatically refresh after a Resource Status change
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
