### PR TITLE
change cluster to workspace

### DIFF
--- a/locales/en/l10n-projects-projectSettings-networkIsolation.js
+++ b/locales/en/l10n-projects-projectSettings-networkIsolation.js
@@ -18,7 +18,7 @@
 
 module.exports = {
   // Banner
-  NETWORK_ISOLATION_DESC: 'By configuring network isolation, users can control traffic between pods within the same cluster and traffic from outside to implement application isolation and enhance application security.',
+  NETWORK_ISOLATION_DESC: 'By configuring network isolation, users can control traffic between pods within the same workspace and traffic from outside to implement application isolation and enhance application security.',
   NETWORK_ISOLATION_Q: 'How do I use network isolation better?',
   NETWORK_ISOLATION_Q1: 'What are the requirements on the CNI plugin for implementing network isolation?',
   // Network Isolation
@@ -29,15 +29,15 @@ module.exports = {
   NETWORK_POLICY_EMP_DESC: 'After the project network access is enabled, other projects will be unable to access the project. But you can allow projects, services, and external IP addresses to access this project based on your needs.',
   // Network Isolation > Internal Allowlist
   INTERNAL_ALLOWLIST: 'Internal Allowlist',
-  INTERNAL_ALLOWLIST_TIP: 'Add projects and services in the cluster to the allowlist.',
+  INTERNAL_ALLOWLIST_TIP: 'Add projects and services in the workspace to the allowlist.',
   INTERNAL_EGRESS_DESC: 'Pods in the current project are allowed to access pods of the following services and projects.',
   INTERNAL_INGRESS_DESC: 'Pods in the current project are allowed to be accessed by pods of the following services and projects.',
-  INTERNAL_ALLOWLIST_DESC: 'Allow pods in the current project to communicate with pods in other projects of the current cluster.',
+  INTERNAL_ALLOWLIST_DESC: 'Allow pods in the current project to communicate with pods in other projects of the current workspace.',
   EMPTY_RESOURCE_DESC: 'Please select at least one project or service.',
   // Network Isolation > External Allowlist
   EXTERNAL_ALLOWLIST: 'External Allowlist',
-  EXTERNAL_ALLOWLIST_TIP: 'Add network segments and ports outside the cluster to the allowlist.',
-  EXTERNAL_ALLOWLIST_DESC: 'Allow pods in the current project to communicate with specific network segments and ports outside the cluster.',
+  EXTERNAL_ALLOWLIST_TIP: 'Add network segments and ports outside the workspace to the allowlist.',
+  EXTERNAL_ALLOWLIST_DESC: 'Allow pods in the current project to communicate with specific network segments and ports outside the workspace.',
   NETWORK_SEGMENT_EXAMPLE: 'Example: 10.0.0.0',
   PORT_EXAMPLE: 'Example: 80',
   EXTERNAL_EGRESS_DESC: 'Pods in the current project are allowed to access the following network segments and ports.',
@@ -47,7 +47,7 @@ module.exports = {
   ENTER_VALID_PORT_NUMBER_DESC: 'Please enter a valid port number.',
   // Add Allowlist Entry
   ADD_ALLOWLIST_ENTRY: 'Add Allowlist Entry',
-  EXTERNAL_TRAFFIC_DIRECTION_DESC: 'Egress indicates the direction from the current project to outside the cluster. Ingress indicates the direction from outside the cluster to the current project.',
+  EXTERNAL_TRAFFIC_DIRECTION_DESC: 'Egress indicates the direction from the current project to outside the workspace. Ingress indicates the direction from outside the workspace to the current project.',
   TRAFFIC_DIRECTION: 'Traffic Direction',
   NETWORK_SEGMENT_DESC: 'Set a network segment (CIDR is supported).',
   EGRESS: 'Egress',


### PR DESCRIPTION
Signed-off-by: Bettygogo2021 <bettygogo@kubesphere.io>
/assign @harrisonliu5 @zheng1 @wenxin-01 
Pls help review and merge this PR.
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
  none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
