### PR TITLE
fix: System-workspace cluster field shows 'all' for multi-cluster 

### DIFF
--- a/locales/en/l10n-accessControl-workspaces-list.js
+++ b/locales/en/l10n-accessControl-workspaces-list.js
@@ -22,6 +22,7 @@ module.exports = {
   WORKSPACE_DESC: 'A workspace is an isolated logical unit used to organize projects and DevOps projects, manage resource access, and share information within your team.',
   // List
   CLUSTER_PL: 'Clusters',
+  ALL_CLUSTERS: 'All Clusters',
   // List > Create > Basic Information
   CREATE_WORKSPACE: 'Create Workspace',
   WORKSPACE_NAME_EMPTY_DESC: 'Please enter a workspace name.',

--- a/src/components/Clusters/ClusterWrapper/index.jsx
+++ b/src/components/Clusters/ClusterWrapper/index.jsx
@@ -47,6 +47,7 @@ export default class ClusterWrapper extends Component {
               </Tag>
             )
           })}
+          {clusters.length === 0 && '-'}
         </div>
       </div>
     )

--- a/src/pages/access/containers/Workspaces/index.jsx
+++ b/src/pages/access/containers/Workspaces/index.jsx
@@ -18,7 +18,7 @@
 
 import React from 'react'
 import { computed } from 'mobx'
-
+import { Tag } from '@kube-design/components'
 import { Avatar } from 'components/Base'
 import Banner from 'components/Cards/Banner'
 import withList, { ListPage } from 'components/HOCs/withList'
@@ -142,9 +142,15 @@ export default class Workspaces extends React.Component {
         title: t('CLUSTER_PL'),
         dataIndex: 'clusters',
         width: '30%',
-        render: clusters => (
-          <ClusterWrapper clusters={clusters} clustersDetail={this.clusters} />
-        ),
+        render: (clusters, { name }) =>
+          name === 'system-workspace' ? (
+            <Tag type="secondary">{t('ALL_CLUSTERS')}</Tag>
+          ) : (
+            <ClusterWrapper
+              clusters={clusters}
+              clustersDetail={this.clusters}
+            />
+          ),
       })
     }
 

--- a/src/pages/workspaces/components/Modals/WorkspaceSelect/Card/index.jsx
+++ b/src/pages/workspaces/components/Modals/WorkspaceSelect/Card/index.jsx
@@ -18,6 +18,7 @@
 
 import { isEmpty } from 'lodash'
 import React from 'react'
+import { Tag } from '@kube-design/components'
 import { List } from 'components/Base'
 import ClusterWrapper from 'components/Clusters/ClusterWrapper'
 import { getLocalTime } from 'utils'
@@ -35,16 +36,17 @@ export default class WorkspaceCard extends React.Component {
 
     const details = [
       {
-        title: isEmpty(data.clusters) ? (
-          '-'
-        ) : (
-          <ClusterWrapper
-            clusters={data.clusters}
-            clustersDetail={clustersDetail}
-          />
-        ),
-        className: styles.clusters,
-        description: t('CLUSTER_INFORMATION'),
+        title:
+          data.name === 'system-workspace' ? (
+            <Tag type="secondary">{t('ALL_CLUSTERS')}</Tag>
+          ) : isEmpty(data.clusters) ? (
+            '-'
+          ) : (
+            <ClusterWrapper
+              clusters={data.clusters}
+              clustersDetail={clustersDetail}
+            />
+          ),
       },
       {
         title: data.createTime


### PR DESCRIPTION
Signed-off-by: yazhou <git@yazhou.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
System-workspace cluster field shows 'all' for multi-cluster 
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/issues/issues/184
Fixes #https://github.com/kubesphere/console/issues/4043
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: System-workspace cluster field shows 'all' for multi-cluster 
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
