### PR TITLE
fix: Fix the image not match when created service by jar/war

### DIFF
--- a/src/components/Forms/ImageBuilder/B2IForm/BinaryFileUploader/index.scss
+++ b/src/components/Forms/ImageBuilder/B2IForm/BinaryFileUploader/index.scss
@@ -70,14 +70,14 @@
       height: 20px;
       padding-top: 6px;
       display: block;
+      width: 100%;
 
       :global(.lego-progress-inner) {
         height: 8px;
         border-radius: 2px;
         background-color: $light-color02;
-
       }
-      :global(.lego-progress-bg){
+      :global(.lego-progress-bg) {
         height: 8px;
         border-radius: 2px;
         background-color: $primary;

--- a/src/components/Forms/Service/ContainerSetting/index.jsx
+++ b/src/components/Forms/Service/ContainerSetting/index.jsx
@@ -105,24 +105,42 @@ export default class ContainerSetting extends React.Component {
   }
 
   updatePullSecrets = formData => {
-    const pullSecrets = {}
-
     const imagePullSecretsPath = `${this.prefix}spec.imagePullSecrets`
+    const annotationsImagePullSecretsPath = `${this.prefix}metadata.annotations["kubesphere.io/imagepullsecrets"]`
 
     const containers = get(formData, `${this.prefix}spec.containers`, [])
+
+    const propsPullSecret = get(
+      this.props.formTemplate,
+      'S2i.spec.config.pushAuthentication.secretRef.name',
+      ''
+    )
+
+    const annotationOfImagePullSecrets = {}
+
     containers.forEach(container => {
-      if (container.pullSecret) {
-        pullSecrets[container.pullSecret] = ''
+      if (propsPullSecret) {
+        annotationOfImagePullSecrets[container.name] = propsPullSecret
       }
     })
 
     set(
       formData,
       imagePullSecretsPath,
-      !isEmpty(pullSecrets)
-        ? Object.keys(pullSecrets).map(key => ({ name: key }))
+      !isEmpty(annotationOfImagePullSecrets)
+        ? Object.values(annotationOfImagePullSecrets).map(value => ({
+            name: value,
+          }))
         : null
     )
+
+    if (!isEmpty(annotationOfImagePullSecrets)) {
+      set(
+        formData,
+        annotationsImagePullSecretsPath,
+        JSON.stringify(annotationOfImagePullSecrets)
+      )
+    }
   }
 
   updateService = formData => {

--- a/src/stores/service.js
+++ b/src/stores/service.js
@@ -57,13 +57,6 @@ const updateS2iServiceParams = data => {
     data.S2i,
     'spec.config.tag'
   )}`
-  // set private image repo secret to deployment
-  const pullSecret = get(
-    data.S2i,
-    'spec.config.pushAuthentication.secretRef.name',
-    ''
-  )
-  set(serviceData, 'spec.template.spec.imagePullSecrets[0].name', pullSecret)
   set(data, 'S2i.metadata.annotations.serviceName', serviceName)
   data.S2i.metadata.name = builderName
   set(serviceData, 'metadata.labels.s2ibuilder', builderName)


### PR DESCRIPTION
Signed-off-by: harrisonliu5 <harrisonliu@kubesphere.io>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/5410

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Fix the image not match when created service by jar/war
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
