### PR TITLE
feat: add devops locale

### DIFF
--- a/locales/en/l10n-devopsProjects-pipeline-details.js
+++ b/locales/en/l10n-devopsProjects-pipeline-details.js
@@ -231,6 +231,7 @@ module.exports = {
     // detail page -> pipeline configuration tab
   PIPELINE_CONFIGURATION: 'Pipeline Configuration',
   Replay: 'Replay',
+  BRANCH_DISABLED_NOT_REPLAY: 'The branch is disabled and cannot be replayed.',
   // detail page // run log // task status
   RUN_LOGS: 'Run Logs',
   VIEW_FULL_LOG: 'View Full Logs',

--- a/locales/en/l10n-devopsProjects-pipeline-details.js
+++ b/locales/en/l10n-devopsProjects-pipeline-details.js
@@ -229,9 +229,9 @@ module.exports = {
   'New Image Tag': 'New Image Tag',
   Credential: 'Credential',
     // detail page -> pipeline configuration tab
-  PIPELINE_CONFIGURATION: 'Pipeline Configuration',
+  PIPELINE_CONFIGURATION: 'Pipeline Configurations',
   Replay: 'Replay',
-  BRANCH_DISABLED_NOT_REPLAY: 'The branch is disabled and cannot be replayed.',
+  BRANCH_DISABLED_NOT_REPLAY: 'The branch has been disabled and cannot be replayed.',
   // detail page // run log // task status
   RUN_LOGS: 'Run Logs',
   VIEW_FULL_LOG: 'View Full Logs',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
feat: add devops locale
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/issues/issues/1198
### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
