### PR TITLE
Update: update alerts

### DIFF
--- a/locales/en/l10n-clusterManagement-baseicInformation.js
+++ b/locales/en/l10n-clusterManagement-baseicInformation.js
@@ -20,7 +20,5 @@ module.exports = {
     // base info modal
     INVALID_ALIAS_NAME_DESC:
       'Invalid alias name. The alias name can contain only letters, numbers, and hyphens (-), and cannot start or end with a hyphen. The maximum length is 63 characters.',
-    ALIAS_NAME_DESC:
-      'The alias name can contain only letters, numbers, and hyphens (-), and cannot start or end with a hyphen. The maximum length is 63 characters.',
   }
   

--- a/locales/en/l10n-clusterManagement-monitoring&Alerting-alertingPolicies-details.js
+++ b/locales/en/l10n-clusterManagement-monitoring&Alerting-alertingPolicies-details.js
@@ -30,7 +30,6 @@ module.exports = {
   DETAILS_COLON: 'Details: ',
   NODES_VALUES: 'Nodes: {values}',
   TRIGGER_CONDITION: 'Trigger Condition',
-  ALERT_RULE_TEXT_PERCENT_MINUTE: '{alterTypeText} {comparator} {thresholds}% for {durationValue, plural, =1 {1 minute} other {# minutes}}',
   MESSAGE_SUMMARY: 'Summary',
   MESSAGE_DETAILS: 'Details',
   VIEW_METRIC_DATA_TCAP: 'View Metric Data',

--- a/locales/en/l10n-clusterManagement-monitoring&Alerting-alertingPolicies-list.js
+++ b/locales/en/l10n-clusterManagement-monitoring&Alerting-alertingPolicies-list.js
@@ -54,8 +54,8 @@ module.exports = {
   // List > Create > Rule Settings > Rule List
   ADD_ALERTING_RULE: "Add Alert Rule",
   ADD_ALERTING_RULE_DESC: "Add an alert rule to the rule group.",
-  ENABLE_RULE: 'Enable rule',
-  DISABLE_RULE: 'Disable rule',
+  ENABLE_RULE: 'Enable Rule',
+  DISABLE_RULE: 'Disable Rule',
   // List > Create > Rule Settings > Rule Template
   RULE_NAME: 'Rule Name',
   CUSTOM_RULE_NAME_DESC: 'The rule name can contain any characters. The maximum length is 63 characters.',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
 none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
