### PR TITLE
fix: batch/v1beta1 removed in v1.25 (4162)

### DIFF
--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -961,7 +961,7 @@ export const API_VERSIONS = {
   statefulsets: 'apis/apps/v1',
   daemonsets: 'apis/apps/v1',
   jobs: 'apis/batch/v1',
-  cronjobs: 'apis/batch/v1beta1',
+  cronjobs: 'apis/batch/v1',
   pods: 'api/v1',
   namespaces: 'api/v1',
   services: 'api/v1',

--- a/src/utils/form.templates.js
+++ b/src/utils/form.templates.js
@@ -184,7 +184,7 @@ const getJobTemplate = ({ namespace }) => ({
 })
 
 const getCronJobTemplate = ({ namespace }) => ({
-  apiVersion: 'batch/v1beta1',
+  apiVersion: 'batch/v1',
   kind: 'CronJob',
   metadata: {
     namespace,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #4162

### Special notes for reviewers:
```
kubernetes removed api version 'batch/v1beta1' in v1.25

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Other doc]: <https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125>
```
