### PR TITLE
style: fix incorrect style for IsolateInfo and RuleInfo of Network Policy panel

### DIFF
--- a/src/pages/projects/containers/Network/Policies/IsolateInfo/index.scss
+++ b/src/pages/projects/containers/Network/Policies/IsolateInfo/index.scss
@@ -1,23 +1,28 @@
 @import '~scss/variables';
+
 .wrapper {
   display: flex;
   align-items: center;
   margin-bottom: 12px;
+  padding: 0px 12px;
 }
+
 .left {
   flex: 1;
   display: flex;
-  padding: 0px 12px;
+
   :global {
     .icon {
       margin-left: 8px;
     }
   }
 }
+
 .isolate {
   margin-left: 15px;
   color: $dark-color01;
 }
+
 .isolatetitle {
   font-weight: 600;
   color: $dark-color07;

--- a/src/pages/projects/containers/Network/Policies/RuleInfo/index.scss
+++ b/src/pages/projects/containers/Network/Policies/RuleInfo/index.scss
@@ -1,18 +1,22 @@
 @import '~scss/variables';
+
 .wrapper {
   box-shadow: 0 -1px 0 0 $light-color04;
 }
+
 .tabs {
   display: flex;
-  padding-left: 20px;
   background-color: $light-color02;
 }
+
 .tab {
   display: flex;
   align-items: center;
   padding: 12px;
   cursor: pointer;
+  flex: 1;
 }
+
 .on {
   background-color: #fff;
 }
@@ -21,6 +25,7 @@
   margin-left: 12px;
   color: $dark-color01;
 }
+
 .dictitle {
   color: $dark-color07;
   font-weight: 600;
@@ -36,9 +41,11 @@
   padding: 0 12px;
   background-color: $light-color01;
 }
+
 .rulebody {
   padding: 20px;
 }
+
 .rulegroup {
   &:first-child {
     margin-bottom: 12px;
@@ -50,10 +57,12 @@
   line-height: 1.67;
   font-weight: 600;
 }
+
 .disp {
   color: $dark-color01;
   line-height: 1.67;
 }
+
 .row {
   display: flex;
   background-color: $light-color02;
@@ -62,24 +71,30 @@
   margin-top: 8px;
   justify-content: space-between;
   align-items: center;
+
   & > :last-child {
     flex: none;
     margin: 0 20px;
     cursor: pointer;
   }
 }
+
 .prow {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
 }
+
 .cell {
   margin: 12px 20px;
+
   & > :first-child {
     margin-right: 8px;
   }
+
   b {
     margin-right: 8px;
+
     span {
       padding: 0 2px;
     }
@@ -91,17 +106,21 @@
     }
   }
 }
+
 .pcell {
   margin: 12px 20px 12px 40px;
+
   & > :first-child {
     margin-right: 8px;
   }
+
   :global {
     label {
       color: $dark-color01;
     }
   }
 }
+
 .port {
   margin: 12px 12px 12px 10px;
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes #4179 

#### Before

<img width="1401" alt="image" src="https://github.com/kubesphere/console/assets/11081491/dcbaa7f2-c1fa-4e77-945f-65911f93a3e6">
<img width="1401" alt="image" src="https://github.com/kubesphere/console/assets/11081491/0f04a339-4f4f-41ca-bcef-09d42195cb0a">
<img width="1401" alt="image" src="https://github.com/kubesphere/console/assets/11081491/077f9d68-eaf9-40c7-afd7-65d00dcc049d">

#### After

<img width="1401" alt="image" src="https://github.com/kubesphere/console/assets/11081491/a371139d-5e74-4b4c-a40d-35a473f56422">

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Fixed the incorrect style for IsolateInfo and RuleInfo of Network Policy panel.
```