### PR TITLE
fixed:The 0 in the front of pvc autosizer input can not be deleted #4174

### DIFF
--- a/src/components/Inputs/UnitSlider/index.jsx
+++ b/src/components/Inputs/UnitSlider/index.jsx
@@ -18,8 +18,9 @@
 
 import React from 'react'
 import { Slider } from '@kube-design/components'
-
+import { cloneDeep, get } from "lodash"
 export default class UnitSlider extends React.Component {
+  innerRef = React.createRef();
   handleChange = value => {
     const { onChange, unit } = this.props
     let newValue = value
@@ -31,6 +32,11 @@ export default class UnitSlider extends React.Component {
 
   render() {
     const { onChange, ...rest } = this.props
-    return <Slider onChange={this.handleChange} {...rest} />
+    if (get(this.innerRef, 'current') && get(this.innerRef, 'current.value')) {
+      let result = cloneDeep(this.innerRef);
+      result.current.value = Number(this.innerRef.current.value) > 0 ? Number(this.innerRef.current.value) : this.innerRef.current.value;
+      this.innerRef = result;
+    };
+    return <Slider onChange={this.handleChange} {...rest} innerRef={this.innerRef} />
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes https://github.com/kubesphere/console/issues/4174

### Special notes for reviewers:
```
In addition, add two variables to the file in this path。
path：`\node_modules\@kube-design\components\esm\components\Slider\Slider.js`
![image](https://github.com/kubesphere/console/assets/109194125/f455ae10-aee2-4d21-92b0-462125716e87)

The code position in the file under this path：
code:
      var _this$props8 = this.props,
          className = _this$props8.className,
          style = _this$props8.style,
          railStyle = _this$props8.railStyle,
          trackStyle = _this$props8.trackStyle,
          range = _this$props8.range,
          unit = _this$props8.unit,
          withInput = _this$props8.withInput,
          min = _this$props8.min,
          max = _this$props8.max,
          innerRef = _this$props8.innerRef; // 新增变量

React.createElement(Input, {
        type: "number",
        value: value[1],
        onChange: this.handleInputChange,
        max: max,
        min: min,
        innerRef: innerRef  // 新增变量
      })

```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
