### PR TITLE
fix: No termination seconds in multi project (#1001)

### DIFF
--- a/src/components/EditForms/Workload/TerminationSeconds/index.jsx
+++ b/src/components/EditForms/Workload/TerminationSeconds/index.jsx
@@ -23,7 +23,7 @@ import TerminationSecondsForm from 'components/Forms/Workload/ContainerSettings/
 
 class TerminationSeconds extends React.Component {
   render() {
-    const { formTemplate, formRef, formProps } = this.props
+    const { formTemplate, formRef, formProps, isFederated } = this.props
 
     return (
       <div className="margin-t12">
@@ -34,7 +34,7 @@ class TerminationSeconds extends React.Component {
             keepDataWhenUnCheck
             checkable
           >
-            <TerminationSecondsForm />
+            <TerminationSecondsForm isFederated={isFederated} />
           </Form.Group>
         </Form>
       </div>

--- a/src/components/Forms/Workload/ContainerSettings/TerminationSeconds/index.jsx
+++ b/src/components/Forms/Workload/ContainerSettings/TerminationSeconds/index.jsx
@@ -22,7 +22,12 @@ import { NumberInput } from 'components/Inputs'
 
 export default class TerminationSeconds extends React.Component {
   get prefix() {
-    return this.props.prefix || 'spec.template.'
+    const { isFederated, prefix } = this.props
+
+    return (
+      prefix ||
+      (isFederated ? 'spec.template.spec.template.' : 'spec.template.')
+    )
   }
 
   render() {

--- a/src/pages/fedprojects/components/ConfigTemplate/config.js
+++ b/src/pages/fedprojects/components/ConfigTemplate/config.js
@@ -22,6 +22,7 @@ import VolumeSettings from 'components/EditForms/Workload/VolumeSettings'
 import Affinity from 'components/EditForms/Workload/Affinity'
 import ServiceSetting from 'fedprojects/components/ServiceSetting'
 import ClusterDiffSettings from 'fedprojects/components/ClusterDiffSettings'
+import TerminationSeconds from 'components/EditForms/Workload/TerminationSeconds'
 
 export default {
   deployments: [
@@ -50,6 +51,12 @@ export default {
       component: Affinity,
     },
     {
+      icon: 'forbid-right-duotone',
+      name: 'podMode',
+      title: 'POD_GRACE_PERIOD',
+      component: TerminationSeconds,
+    },
+    {
       title: 'CLUSTER_DIFF',
       icon: 'blue-green-deployment',
       name: 'Diff Settings',
@@ -68,6 +75,12 @@ export default {
       name: 'podTemplate',
       title: 'CONTAINER_PL',
       component: PodTemplate,
+    },
+    {
+      icon: 'forbid-right-duotone',
+      name: 'podMode',
+      title: 'POD_GRACE_PERIOD',
+      component: TerminationSeconds,
     },
     {
       icon: 'storage',

--- a/src/pages/projects/components/Modals/ConfigTemplate/config.js
+++ b/src/pages/projects/components/Modals/ConfigTemplate/config.js
@@ -76,6 +76,12 @@ export default {
       component: PodTemplate,
     },
     {
+      icon: 'forbid-right-duotone',
+      name: 'podMode',
+      title: 'POD_GRACE_PERIOD',
+      component: TerminationSeconds,
+    },
+    {
       icon: 'storage',
       name: 'volumeSettings',
       title: 'STORAGE',
@@ -100,6 +106,12 @@ export default {
       name: 'volumeSettings',
       title: 'STORAGE',
       component: VolumeSettings,
+    },
+    {
+      icon: 'forbid-right-duotone',
+      name: 'podMode',
+      title: 'POD_GRACE_PERIOD',
+      component: TerminationSeconds,
     },
   ],
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix: No termination seconds in multi project (#1001)
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/5830
link #https://github.com/kubesphere/issues/issues/865

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
