### PR TITLE
fix: Set disabled when cluster is not ready or not install devops

### DIFF
--- a/src/pages/workspaces/containers/DevOps/index.jsx
+++ b/src/pages/workspaces/containers/DevOps/index.jsx
@@ -19,7 +19,7 @@
 import { Avatar, Status } from 'components/Base'
 import Banner from 'components/Cards/Banner'
 import withList, { ListPage } from 'components/HOCs/withList'
-import { computed } from 'mobx'
+import { computed, toJS } from 'mobx'
 import React from 'react'
 
 import DevOpsStore from 'stores/devops'
@@ -84,12 +84,18 @@ export default class DevOps extends React.Component {
 
   @computed
   get clusters() {
-    return this.workspaceStore.clusters.data.map(item => ({
-      label: item.name,
-      value: item.name,
-      disabled: !item.isReady,
-      cluster: item,
-    }))
+    const list = this.workspaceStore.clusters.data
+      .map(item => ({
+        label: item.name,
+        value: item.name,
+        disabled: !item.isReady || !item.configz?.devops,
+        cluster: toJS(item),
+      }))
+      .sort((a, b) => a.disabled - b.disabled)
+    if (list[0]) {
+      this.workspaceStore.cluster = list[0]?.value
+    }
+    return list
   }
 
   get clusterProps() {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix: Set disabled when cluster is not ready or not install devops
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/ks-devops/issues/607

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
