### PR TITLE
fix: Fix parameters defined in pipeline not passed to jenkins

### DIFF
--- a/src/components/Forms/Pipelines/ParamsFormModal/index.jsx
+++ b/src/components/Forms/Pipelines/ParamsFormModal/index.jsx
@@ -142,6 +142,10 @@ export default class ParamsFormModal extends React.Component {
     const { parameters, currentBranch } = this.state
 
     this.formRef.current.validate(() => {
+      if (!isEmpty(formParameters) && formParameters.__branch) {
+        formParameters.branch = formParameters.__branch
+        delete formParameters.__branch
+      }
       const params = isEmpty(formParameters)
         ? !isEmpty(parameters) && Array.isArray(parameters)
           ? parameters.map(item => ({
@@ -171,7 +175,10 @@ export default class ParamsFormModal extends React.Component {
             label={param.name}
             desc={param.description}
           >
-            <Input defaultValue={defaultValue} name={param.name} />
+            <Input
+              defaultValue={defaultValue}
+              name={param.name === 'branch' ? '__branch' : param.name}
+            />
           </Form.Item>
         )
       case 'text':


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix: Fix parameters defined in pipeline not passed to jenkins
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/ks-devops/issues/980

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
