### PR TITLE
fix: notify message before run pipeline

### DIFF
--- a/src/actions/pipeline.js
+++ b/src/actions/pipeline.js
@@ -259,6 +259,7 @@ export default {
     on({ store, success, devops, cluster, ...props }) {
       const modal = Modal.open({
         onOk: async (parameters, branch) => {
+          Notify.success({ content: `${t('PIPELINE_RUN_START_SI')}` })
           await store.runBranch({
             devops,
             name: props.params.name,

--- a/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
+++ b/src/pages/devops/containers/Pipelines/Detail/Activity/index.jsx
@@ -145,7 +145,6 @@ export default class Activity extends React.Component {
         disabledBrancheNames: toJS(detail.disabledBrancheNames),
         parameters: toJS(detail.parameters),
         success: () => {
-          Notify.success({ content: `${t('PIPELINE_RUN_START_SI')}` })
           this.handleFetch()
         },
       })


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
fix: Notify message before run pipeline
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/ks-devops/issues/986

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
