### PR TITLE
fix: Fix deploy the app by template not get the detail

### DIFF
--- a/src/pages/apps/components/Modals/AppDeploy/index.jsx
+++ b/src/pages/apps/components/Modals/AppDeploy/index.jsx
@@ -30,7 +30,7 @@ import AppConfig from 'components/Forms/AppDeploy/AppConfig'
 import VersionStore from 'stores/openpitrix/version'
 import AppFileStore from 'stores/openpitrix/file'
 
-import { generateId, showNameAndAlias } from 'utils'
+import { generateId } from 'utils'
 
 import Steps from './Steps'
 
@@ -60,14 +60,18 @@ export default class AppDeploy extends React.Component {
   constructor(props) {
     super(props)
 
+    const appName = props.app.name
+
     this.state = {
       currentStep: 0,
       formData: {
         app_id: props.app.app_id,
-        name: `${props.app.name
-          .slice(0, 7)
-          .toLowerCase()
-          .replaceAll(' ', '-')}-${generateId()}`,
+        name: appName
+          ? `${appName
+              ?.slice(0, 7)
+              .toLowerCase()
+              .replaceAll(' ', '-')}-${generateId()}`
+          : '',
         version_id: props.versionId,
         namespace: props.namespace,
         cluster: props.cluster,
@@ -165,9 +169,9 @@ export default class AppDeploy extends React.Component {
 
     const props = {
       formData,
-      cluster: showNameAndAlias(cluster, 'cluster'),
-      workspace: showNameAndAlias(workspace, 'workspace'),
-      namespace: showNameAndAlias(namespace, 'project'),
+      cluster,
+      workspace,
+      namespace,
       versionId,
       versionStore: this.versionStore,
       fileStore: this.fileStore,

--- a/src/stores/openpitrix/base.js
+++ b/src/stores/openpitrix/base.js
@@ -83,9 +83,10 @@ export default class Base {
     }
 
     if (app_id) {
-      const suffix1 = this.resourceName === 'apps' ? '' : this.resourceName
-      const suffix2 = `${name || suffix1}` === '' ? '' : `/${name || suffix1}`
-      return `${prefix}/apps/${app_id}${suffix2}`
+      const suffixName = this.resourceName === 'apps' ? '' : this.resourceName
+      const suffixPath =
+        `${name || suffixName}` === '' ? '' : `/${name || suffixName}`
+      return `${prefix}/apps/${app_id}${suffixPath}`
     }
 
     return `${prefix}/${name || this.resourceName}`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubesphere/kubesphere/issues/5873

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
fix: Fix deploy the app by template not get the detail
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
