### PR TITLE
fix: resolved ProjectSelectModal styles problem

### DIFF
--- a/src/components/Modals/ProjectSelect/index.jsx
+++ b/src/components/Modals/ProjectSelect/index.jsx
@@ -242,12 +242,14 @@ export default class ProjectSelectModal extends React.Component {
         <div className={styles.bar}>
           <Columns className="is-variable is-1">
             <Column className="is-narrow">
-              <RadioGroup
-                mode="button"
-                value={type}
-                options={this.types}
-                onChange={this.handleTypeChange}
-              />
+              <div className={styles.radioGroupWrapper}>
+                <RadioGroup
+                  mode="button"
+                  value={type}
+                  options={this.types}
+                  onChange={this.handleTypeChange}
+                />
+              </div>
             </Column>
             <Column>
               <div className={styles.searchWrapper}>

--- a/src/components/Modals/ProjectSelect/index.scss
+++ b/src/components/Modals/ProjectSelect/index.scss
@@ -12,6 +12,15 @@
   background-color: $bg-color;
 }
 
+.radioGroupWrapper {
+  :global {
+    .radio-group-button label.radio-button {
+      padding-right: 12px;
+      padding-left: 12px;
+    }
+  }
+}
+
 .list {
   height: 472px;
   padding: 12px;
@@ -45,7 +54,7 @@
   }
 
   .search {
-    width: 390px;
+    max-width: 390px;
 
     &.withSelect {
       padding-left: 124px;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubesphere/kubesphere/issues/5972

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
