### PR TITLE
fix: location parameter error

### DIFF
--- a/src/core/layouts/Base/index.jsx
+++ b/src/core/layouts/Base/index.jsx
@@ -68,7 +68,7 @@ class BaseLayout extends Component {
       document.addEventListener('click', this.handleClick)
     }
 
-    if (!globals.user && !isAppsPage(this.props.location.path)) {
+    if (!globals.user && !isAppsPage(this.props.location.pathname)) {
       location.href = '/login'
     }
   }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

`location.path` should be `location.pathname`
[react-router `location` doc](https://reactrouter.com/en/main/utils/location)
[react-router `location` interface](https://github.com/remix-run/history/blob/main/docs/api-reference.md#location)

kubesphere console `src\utils\router.config.js`
```diff
<Route
  key={key}
  exact={route.exact}
  path={route.path}
+  render={props => {
    set(globals, 'currentCluster', props.match.params.cluster)
    set(globals, 'currentWorkspace', props.match.params.workspace)
    if (route.render) {
      return route.render(props)
    }
    return (
      <route.component {...props} {...extraProps} route={route} />
    )
  }}
  strict={route.strict}
/>
```
react-router render

```diff
  _proto.render = function render() {
    var _this$props2 = this.props,
        _this$props2$basename = _this$props2.basename,
        basename = _this$props2$basename === void 0 ? "" : _this$props2$basename,
        _this$props2$context = _this$props2.context,
        context = _this$props2$context === void 0 ? {} : _this$props2$context,
        _this$props2$location = _this$props2.location,
        location = _this$props2$location === void 0 ? "/" : _this$props2$location,
        rest = _objectWithoutPropertiesLoose(_this$props2, ["basename", "context", "location"]);

    var history$1 = {
      createHref: function createHref(path) {
        return addLeadingSlash(basename + createURL(path));
      },
      action: "POP",
+     location: stripBasename(basename, history.createLocation(location)),
      push: this.handlePush,
      replace: this.handleReplace,
      go: staticHandler("go"),
      goBack: staticHandler("goBack"),
      goForward: staticHandler("goForward"),
      listen: this.handleListen,
      block: this.handleBlock
    };
    return React.createElement(Router, _extends({}, rest, {
      history: history$1,
      staticContext: context
    }));
  };

  return StaticRouter;
}(React.Component);
```

history.createLocation

```diff
function createLocation(path, state, key, currentLocation) {
  var location;

  if (typeof path === 'string') {
    // Two-arg form: push(path, state)
    location = parsePath(path);
    location.state = state;
  } else {
    // One-arg form: push(location)
    location = _extends({}, path);
+    if (location.pathname === undefined) location.pathname = '';

    if (location.search) {
      if (location.search.charAt(0) !== '?') location.search = '?' + location.search;
    } else {
      location.search = '';
    }

    if (location.hash) {
      if (location.hash.charAt(0) !== '#') location.hash = '#' + location.hash;
    } else {
      location.hash = '';
    }

    if (state !== undefined && location.state === undefined) location.state = state;
  }

  try {
+    location.pathname = decodeURI(location.pathname);
  } catch (e) {
    if (e instanceof URIError) {
      throw new URIError('Pathname "' + location.pathname + '" could not be decoded. ' + 'This is likely caused by an invalid percent-encoding.');
    } else {
      throw e;
    }
  }

  if (key) location.key = key;

  if (currentLocation) {
    // Resolve incomplete/relative pathname relative to current location.
+    if (!location.pathname) {
      location.pathname = currentLocation.pathname;
    } else if (location.pathname.charAt(0) !== '/') {
      location.pathname = resolvePathname(location.pathname, currentLocation.pathname);
    }
  } else {
    // When there is no prior location and pathname is empty, set it to /
+    if (!location.pathname) {
      location.pathname = '/';
    }
  }

  return location;
}
```



### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
- [react-router `location` doc]: <https://reactrouter.com/en/main/utils/location>
- [react-router `location` interface]: <https://github.com/remix-run/history/blob/main/docs/api-reference.md#location>
```
