### PR TITLE
fix: resourceStatus get podNums

### DIFF
--- a/src/pages/projects/containers/Deployments/Detail/ResourceStatus/index.jsx
+++ b/src/pages/projects/containers/Deployments/Detail/ResourceStatus/index.jsx
@@ -37,10 +37,10 @@ class ResourceStatus extends React.Component {
     super(props)
 
     this.hpaStore = props.hpaStore || new HpaStore()
-
+    const detail = toJS(props.detailStore.detail)
     this.state = {
-      podNums: props.detailStore.podNums,
-      availablePodNums: props.detailStore.availablePodNums,
+      podNums: detail.podNums,
+      availablePodNums: detail.availablePodNums,
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10904,8 +10904,8 @@ react-file-reader@^1.1.4:
 
 react-input-autosize@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.npm.taobao.org/react-input-autosize/download/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
-  integrity sha1-a1iYx5DUR41pQgtVRB/MMdXFCoU=
+  resolved "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

Add one of the following kinds:
/kind bug
<!-- 
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
