### PR TITLE
fix: fix the issue of checking licenses in ks

### DIFF
--- a/packages/bootstrap/webpack/webpack.base.conf.js
+++ b/packages/bootstrap/webpack/webpack.base.conf.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs-extra');
 const { config, systemImports } = require('./config');
+const webpack = require('webpack');
 const WebpackBar = require('webpackbar');
 const { merge } = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -87,6 +88,9 @@ const webpackBaseConfig = merge(configs, {
     ],
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env.KUBESPHERE_EDITION': JSON.stringify('ks'),
+    }),
     new ForkTsCheckerWebpackPlugin(),
     new CopyWebpackPlugin({
       patterns: [

--- a/packages/shared/src/components/Layouts/NavMenu/NavItem/index.tsx
+++ b/packages/shared/src/components/Layouts/NavMenu/NavItem/index.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom';
 import { ChevronDown } from '@kubed/icons';
 
 import type { LicenseAuthorizationStatus } from '../../../../types/license';
+import { ENV } from '../../../../constants';
 import { LicenseErrorTip } from '../../../../index';
 import Icon from '../../../Icon';
 
@@ -56,6 +57,8 @@ interface NavItemProps {
   disabled?: boolean;
 }
 
+const isCheckLicense = ENV.isKseEdition;
+
 const NavItem = ({ item, onOpen, isOpen, pathArr, prefix, disabled }: NavItemProps) => {
   const handleToggle = () => {
     onOpen(item?.name || '');
@@ -73,9 +76,10 @@ const NavItem = ({ item, onOpen, isOpen, pathArr, prefix, disabled }: NavItemPro
     return pathArr.includes(navItem.name);
   };
 
-  const isItemDisabled = item?.isLicenseError ? true : disabled && !item?.showInDisable;
+  const isItemDisabled =
+    isCheckLicense && item?.isLicenseError ? true : disabled && !item?.showInDisable;
 
-  const itemLicenseErrorTipWrapper = item?.isLicenseError && (
+  const itemLicenseErrorTipWrapper = isCheckLicense && item?.isLicenseError && (
     <LicenseErrorTipWrapper>
       <LicenseErrorTip authorizationStatus={item?.licenseAuthorizationStatus} />
     </LicenseErrorTipWrapper>
@@ -102,7 +106,8 @@ const NavItem = ({ item, onOpen, isOpen, pathArr, prefix, disabled }: NavItemPro
         </TitleWrapper>
         <InnerNav className="inner-nav">
           {item?.children.map((child: NavMenuItem) => {
-            const isChildDisabled = child.isLicenseError ? true : disabled && !child.showInDisable;
+            const isChildDisabled =
+              isCheckLicense && child.isLicenseError ? true : disabled && !child.showInDisable;
 
             return (
               <InnerItem
@@ -117,7 +122,7 @@ const NavItem = ({ item, onOpen, isOpen, pathArr, prefix, disabled }: NavItemPro
                 ) : (
                   <Link to={`${prefix}/${child.name}`}>{t(child.title)}</Link>
                 )}
-                {child.isLicenseError && (
+                {isCheckLicense && child.isLicenseError && (
                   <LicenseErrorTipWrapper>
                     <LicenseErrorTip authorizationStatus={child.licenseAuthorizationStatus} />
                   </LicenseErrorTipWrapper>

--- a/packages/shared/src/constants/env.ts
+++ b/packages/shared/src/constants/env.ts
@@ -6,3 +6,5 @@
 export const isDevelopment = process.env.NODE_ENV === 'development';
 
 export const isProduction = process.env.NODE_ENV === 'production';
+
+export const isKseEdition = process.env.KUBESPHERE_EDITION === 'kse';


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
