### PR TITLE
build: add KUBESPHERE_EDITION constant to config files

### DIFF
--- a/packages/bootstrap/webpack/config.js
+++ b/packages/bootstrap/webpack/config.js
@@ -5,6 +5,8 @@
 
 const path = require('path');
 
+const KUBESPHERE_EDITION = 'ks';
+
 const resolve = absolutePath => path.resolve(process.cwd(), absolutePath);
 
 const rootDir = path.resolve(__dirname, '../');
@@ -46,4 +48,4 @@ const systemImports = {
 
 const locales = ['ar', 'en', 'es', 'fr', 'hi', 'ko', 'lt', 'pl', 'tc', 'tr', 'zh'];
 
-module.exports = { config, systemImports, locales };
+module.exports = { config, systemImports, locales, KUBESPHERE_EDITION };

--- a/packages/bootstrap/webpack/webpack.base.conf.js
+++ b/packages/bootstrap/webpack/webpack.base.conf.js
@@ -4,7 +4,7 @@
  */
 
 const fs = require('fs-extra');
-const { config, systemImports } = require('./config');
+const { config, systemImports, KUBESPHERE_EDITION } = require('./config');
 const webpack = require('webpack');
 const WebpackBar = require('webpackbar');
 const { merge } = require('webpack-merge');
@@ -89,7 +89,7 @@ const webpackBaseConfig = merge(configs, {
   },
   plugins: [
     new webpack.DefinePlugin({
-      'process.env.KUBESPHERE_EDITION': JSON.stringify('ks'),
+      'process.env.KUBESPHERE_EDITION': JSON.stringify(KUBESPHERE_EDITION),
     }),
     new ForkTsCheckerWebpackPlugin(),
     new CopyWebpackPlugin({

--- a/packages/bootstrap/webpack/webpack.dll.conf.js
+++ b/packages/bootstrap/webpack/webpack.dll.conf.js
@@ -10,7 +10,7 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const WebpackBar = require('webpackbar');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const { config: configShared } = require('./config');
+const { config: configShared, KUBESPHERE_EDITION } = require('./config');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const resolveShared = configShared.resolve;
 const absResolve = configShared.absResolve;
@@ -91,6 +91,9 @@ const config = {
     minimizer: [new TerserPlugin()],
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env.KUBESPHERE_EDITION': JSON.stringify(KUBESPHERE_EDITION),
+    }),
     new WebpackBar({
       name: 'build dll',
       color: 'green',


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!-- 
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
