### PR TITLE
fix: Fix the z-index of monitorController modal

### DIFF
--- a/packages/shared/src/components/Base/Card/MonitorController/Modal/index.tsx
+++ b/packages/shared/src/components/Base/Card/MonitorController/Modal/index.tsx
@@ -161,6 +161,7 @@ function MonitorControllerModal({
         step={initializeParams.step}
         times={initializeParams.times}
         onChange={handleChange}
+        zIndex={1000}
       />
       {renderAutoRefresh}
       <IconButton onClick={handleRefresh}>

--- a/packages/shared/src/components/TimeSelector/CustomRange.tsx
+++ b/packages/shared/src/components/TimeSelector/CustomRange.tsx
@@ -27,6 +27,7 @@ interface Props {
   timeOps?: string[];
   onSubmit?: (value: ValueType) => void;
   onCancel?: () => void;
+  zIndex?: number;
 }
 
 interface FormValue {
@@ -77,6 +78,7 @@ function CustomRange({
   timeOps = DEFAULT_TIME_OPTIONS,
   onSubmit,
   onCancel,
+  zIndex = 100,
 }: Props) {
   const formRef = useRef<FormInstance<FormValue>>(null);
 
@@ -120,7 +122,7 @@ function CustomRange({
             disabledDate={disabledDate}
             disabledTime={disabledRangeTime}
             showTime
-            popupStyle={{ zIndex: 100 }}
+            popupStyle={{ zIndex }}
             showNow={false}
             format="YYYY-MM-DD HH:mm:ss"
           ></DatePicker>
@@ -129,7 +131,7 @@ function CustomRange({
           <DatePicker
             disabledDate={disabledDate}
             disabledTime={disabledRangeTime}
-            popupStyle={{ zIndex: 100 }}
+            popupStyle={{ zIndex }}
             showTime
             showNow={false}
             format="YYYY-MM-DD HH:mm:ss"

--- a/packages/shared/src/components/TimeSelector/index.tsx
+++ b/packages/shared/src/components/TimeSelector/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   onChange?: (val: Omit<ValueType, 'lastTime'>) => void;
   onToggle?: (toggled: boolean) => void;
   timeOps?: string[];
+  zIndex?: number;
 }
 
 function TimeSelector({
@@ -34,6 +35,7 @@ function TimeSelector({
   timeOps,
   onChange,
   onToggle,
+  zIndex,
 }: Props) {
   const [visible, setVisible] = useState<boolean>(false);
   const [selfValue, setSelfValue] = useState<ValueType>({
@@ -101,6 +103,7 @@ function TimeSelector({
             showStep={showStep}
             onSubmit={handleTimeChange}
             onCancel={hideSelector}
+            zIndex={zIndex}
           />
         )}
       </Content>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/project/issues/4881

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
