### PR TITLE
fix: Fix delete workspace with deleting project on workspace baseinfo page

### DIFF
--- a/packages/console/src/pages/access/containers/Workspaces/index.tsx
+++ b/packages/console/src/pages/access/containers/Workspaces/index.tsx
@@ -104,7 +104,7 @@ export default function Workspaces(): JSX.Element {
                   (item: { namespace?: string; name: string }) => ({
                     namespace: item.namespace,
                     name: item.name,
-                    deleteProject: checkkboxRef.current,
+                    shouldDeleteResource: checkkboxRef.current,
                     ...params,
                   }),
                 );
@@ -167,7 +167,7 @@ export default function Workspaces(): JSX.Element {
                 const deleteParams = [record].map(item => ({
                   namespace: item.namespace,
                   name: item.name,
-                  deleteProject: checkkboxRef.current,
+                  shouldDeleteResource: checkkboxRef.current,
                   ...params,
                 }));
                 await workspaceStore.batchDelete(deleteParams);

--- a/packages/shared/src/stores/workspace.ts
+++ b/packages/shared/src/stores/workspace.ts
@@ -114,21 +114,14 @@ const patch = async (params: PathParams, data: Record<string, any>) => {
 
 interface DeleteWorkspaceOptions extends PathParams {
   shouldDeleteResource?: boolean;
-  deleteProject?: boolean;
 }
 
-const deleteWorkspace = ({
-  shouldDeleteResource,
-  deleteProject,
-  ...params
-}: DeleteWorkspaceOptions) => {
-  const data = !shouldDeleteResource
-    ? {
-        kind: 'DeleteOptions',
-        apiVersion: 'v1',
-        propagationPolicy: deleteProject ? 'Background' : 'Orphan',
-      }
-    : {};
+const deleteWorkspace = ({ shouldDeleteResource, ...params }: DeleteWorkspaceOptions) => {
+  const data = {
+    kind: 'DeleteOptions',
+    apiVersion: 'v1',
+    propagationPolicy: shouldDeleteResource ? 'Background' : 'Orphan',
+  };
   return request.delete<never, OriginalWorkspace, Record<string, any>>(getDetailUrl(params), {
     data,
   });


### PR DESCRIPTION

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/project/issues/4803

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
