### PR TITLE
fix: add rule on app category name to match backend rule

### DIFF
--- a/locales/en/l10n-appStoreManagement-appCategories-list.js
+++ b/locales/en/l10n-appStoreManagement-appCategories-list.js
@@ -15,6 +15,8 @@ module.exports = {
   ENTER_CATEGORY_NAME_TIP: 'Please enter a category name.',
   CATEGORY_NAME_DESC:
     'The name can contain any characters and the maximum length is 20 characters.',
+  APP_CATEGORY_NAME_DESC:
+    'The name must consist of lower case alphanumeric characters, (-) or (.) and must start and end with an alphanumeric character.',
   // All Categories > Eit
   // All Categories > Delete
   DELETE_CATEGORY_DESC: 'Are you sure you want to delete the category <b>{name}</b>?',

--- a/locales/es/l10n-appStoreManagement-appCategories-list.js
+++ b/locales/es/l10n-appStoreManagement-appCategories-list.js
@@ -15,6 +15,8 @@ module.exports = {
   ENTER_CATEGORY_NAME_TIP: 'Por favor, introduzca un nombre de categoría.',
   CATEGORY_NAME_DESC:
     'El nombre puede contener cualquier carácter y el largo máximo es de 20 caracteres.',
+  APP_CATEGORY_NAME_DESC:
+    'El nombre debe consistir en caracteres alfanuméricos en minúsculas, (-) o (.) y debe comenzar y terminar con un carácter alfanumérico.',
   // All Categories > Eit
   // All Categories > Delete
   DELETE_CATEGORY_DESC: '¿Está seguro que desea eliminar la categoría <b>{name}</b>?',

--- a/locales/tc/l10n-appStoreManagement-appCategories-list.js
+++ b/locales/tc/l10n-appStoreManagement-appCategories-list.js
@@ -13,6 +13,8 @@ module.exports = {
   // All Categories > Add
   ENTER_CATEGORY_NAME_TIP: '請輸入類別名稱。',
   CATEGORY_NAME_DESC: '名稱可包含任意字元，最長 20 個字元。',
+  APP_CATEGORY_NAME_DESC:
+    '名稱只能包含小寫字母、數字、隔符號（-）和點（.），必須以小寫字母或數字開頭及結尾，最長 20 個字元。',
   // All Categories > Eit
   // All Categories > Delete
   DELETE_CATEGORY_DESC: '您確定要刪除類別 <b>{name}</b> 嗎?',

--- a/locales/zh/l10n-appStoreManagement-appCategories-list.js
+++ b/locales/zh/l10n-appStoreManagement-appCategories-list.js
@@ -14,7 +14,9 @@ module.exports = {
   // All Categories > Add
   ENTER_CATEGORY_NAME_TIP: '请输入分类名称。',
   CATEGORY_NAME_DESC: '名称可包含任意字符，最长 20 个字符。',
-  // All Categories > Eit
+  APP_CATEGORY_NAME_DESC:
+    '名称只能包含小写字母、数字、连字符（-）和句点（.），必须以小写字母或数字开头及结尾，最长 20 个字符',
+  // All Categories > Eikt
   // All Categories > Delete
   DELETE_CATEGORY_DESC: '您确定要删除分类 <b>{name}</b> 吗?',
   // List

--- a/packages/shared/src/constants/patterns.ts
+++ b/packages/shared/src/constants/patterns.ts
@@ -38,3 +38,5 @@ export const PATTERN_UTC_TIME = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[
 export const PATTERN_WORD = /(?=.*?[A-Z])(?=.*?[a-z])/;
 export const PATTERN_NUMBER = /(?=.*?[0-9])/;
 export const PATTERN_INTEGER_NUMBER = /^[+]{0,1}(\d+)$/;
+export const PATTERN_APPTEMPLATE_CATEGORY_NAME =
+  /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug 

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/project/issues/4876

### Special notes for reviewers

```
need to make some modifications in openpitrix extension 
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
