### PR TITLE
chore: sync codes

### DIFF
--- a/packages/core/src/containers/Extensions/Management/components/ResetDefaultConfigTip/ResetDefaultConfigConfirmModal.tsx
+++ b/packages/core/src/containers/Extensions/Management/components/ResetDefaultConfigTip/ResetDefaultConfigConfirmModal.tsx
@@ -4,13 +4,12 @@
  */
 
 import React from 'react';
-import type { ModalProps } from '@kubed/components';
-import { Question } from '@kubed/icons';
 
-import { StyledModal, Header, Title, Description } from './ResetDefaultConfigConfirmModal.styles';
+import type { ConfirmModalProps } from '@ks-console/shared';
+import { ConfirmModal } from '@ks-console/shared';
 
 type ResetDefaultConfigConfirmModalProps = Pick<
-  ModalProps,
+  ConfirmModalProps,
   'visible' | 'confirmLoading' | 'onCancel' | 'onOk'
 >;
 
@@ -21,19 +20,14 @@ export function ResetDefaultConfigConfirmModal({
   onOk,
 }: ResetDefaultConfigConfirmModalProps) {
   return (
-    <StyledModal
+    <ConfirmModal
       visible={visible}
-      header={null}
-      closable={false}
+      titleIconProps={{ type: 'info' }}
+      title={t('RESET_DEFAULT_CONFIGURATION_TITLE')}
+      description={t('RESET_DEFAULT_CONFIGURATION_CONFIRM_DESCRIPTION')}
       confirmLoading={confirmLoading}
       onCancel={onCancel}
       onOk={onOk}
-    >
-      <Header>
-        <Question size={20} />
-        <Title>{t('RESET_DEFAULT_CONFIGURATION_TITLE')}</Title>
-      </Header>
-      <Description>{t('RESET_DEFAULT_CONFIGURATION_CONFIRM_DESCRIPTION')}</Description>
-    </StyledModal>
+    />
   );
 }

--- a/packages/shared/src/components/Modals/Confirm/ConfirmModal.constants.ts
+++ b/packages/shared/src/components/Modals/Confirm/ConfirmModal.constants.ts
@@ -1,0 +1,21 @@
+import { Question, Exclamation, Failure } from '@kubed/icons';
+
+export const DEFAULT_TITLE_ICON_PROPS = {
+  size: 20,
+  color: '#fff',
+} as const;
+
+export const TITLE_ICON_TYPE_MAP = {
+  info: {
+    icon: Question,
+    fillColorName: 'blue',
+  },
+  warning: {
+    icon: Exclamation,
+    fillColorName: 'yellow',
+  },
+  error: {
+    icon: Failure,
+    fillColorName: 'red',
+  },
+} as const;

--- a/packages/shared/src/components/Modals/Confirm/ConfirmModal.helpers.tsx
+++ b/packages/shared/src/components/Modals/Confirm/ConfirmModal.helpers.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { merge } from 'lodash';
+import { useTheme } from '@kubed/components';
+
+import type { TitleIconProps, ConfirmModalProps } from './ConfirmModal.types';
+import { DEFAULT_TITLE_ICON_PROPS, TITLE_ICON_TYPE_MAP } from './ConfirmModal.constants';
+
+interface TitleIconOptions {
+  titleIconProps?: TitleIconProps;
+  titleIcon?: ConfirmModalProps['titleIcon'];
+}
+
+export function renderTitleIcon({ titleIconProps, titleIcon }: TitleIconOptions) {
+  const { palette } = useTheme();
+
+  if (titleIcon) {
+    return titleIcon;
+  }
+
+  if (!titleIconProps) {
+    return null;
+  }
+
+  const { icon: Icon, fillColorName } = TITLE_ICON_TYPE_MAP[titleIconProps.type];
+  const defaultProps: Omit<TitleIconProps, 'type'> = {
+    ...DEFAULT_TITLE_ICON_PROPS,
+    fill: palette.colors[fillColorName]?.[2],
+  };
+  const finalProps = merge({}, defaultProps, titleIconProps);
+
+  return <Icon {...finalProps} />;
+}

--- a/packages/shared/src/components/Modals/Confirm/ConfirmModal.styles.ts
+++ b/packages/shared/src/components/Modals/Confirm/ConfirmModal.styles.ts
@@ -25,11 +25,6 @@ export const Header = styled.div`
   display: flex;
   align-items: center;
   column-gap: 4px;
-
-  svg.kubed-icon {
-    color: rgba(255, 255, 255, 0.9);
-    fill: ${({ theme }) => theme.palette.colors.blue[2]};
-  }
 `;
 
 export const Title = styled.h5`

--- a/packages/shared/src/components/Modals/Confirm/ConfirmModal.tsx
+++ b/packages/shared/src/components/Modals/Confirm/ConfirmModal.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import type { ConfirmModalProps } from './ConfirmModal.types';
+import { renderTitleIcon } from './ConfirmModal.helpers';
+import { StyledModal, Header, Title, Description } from './ConfirmModal.styles';
+
+export function ConfirmModal({
+  titleIconProps,
+  titleIcon,
+  title,
+  description,
+  ...rest
+}: ConfirmModalProps) {
+  const hasHeader = title || titleIcon || titleIconProps;
+
+  return (
+    <StyledModal header={null} closable={false} {...rest}>
+      {hasHeader && (
+        <Header>
+          {renderTitleIcon({ titleIconProps, titleIcon })}
+          {title && <Title>{title}</Title>}
+        </Header>
+      )}
+      {description && <Description>{description}</Description>}
+    </StyledModal>
+  );
+}

--- a/packages/shared/src/components/Modals/Confirm/ConfirmModal.types.ts
+++ b/packages/shared/src/components/Modals/Confirm/ConfirmModal.types.ts
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+import type { ModalProps } from '@kubed/components';
+import type { Props } from '@kubed/icons';
+
+export interface TitleIconProps extends Props {
+  type: 'warning' | 'info' | 'error';
+}
+
+export interface ConfirmModalProps extends Omit<ModalProps, 'title' | 'titleIcon'> {
+  titleIconProps?: TitleIconProps;
+  titleIcon?: ReactNode;
+  title?: ReactNode;
+  description?: ReactNode;
+}

--- a/packages/shared/src/components/Modals/Confirm/index.ts
+++ b/packages/shared/src/components/Modals/Confirm/index.ts
@@ -1,0 +1,2 @@
+export type { ConfirmModalProps } from './ConfirmModal.types';
+export * from './ConfirmModal';

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -23,6 +23,7 @@ export { default as Pagination } from './Pagination';
 export { default as Avatar } from './Avatar';
 export { default as StatusReason } from './StatusReason';
 
+export * from './Modals/Confirm';
 export * from './Modals/EnterLicense';
 export * from './Modals/FullScreenModal';
 export * from './Modals/KubeCtl';


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
