### PR TITLE
feat: enhance useUrlSearchParamsStatus hook with reset pageIndex when columnFilters has changed

### DIFF
--- a/packages/shared/src/utils/table/hooks/useUrlSearchParamsStatus.ts
+++ b/packages/shared/src/utils/table/hooks/useUrlSearchParamsStatus.ts
@@ -111,14 +111,24 @@ const pickUrlSearchParams = (params: URLSearchParams | string, pickKeys: string[
   return newParams;
 };
 
-export const useUrlSearchParamsStatus = (omitKeys: string[] = []) => {
+export const useUrlSearchParamsStatus = (
+  omitKeys: string[] = [],
+): {
+  state: Partial<TableState>;
+  setState: (state: Partial<TableState>, type: keyof TableState) => void;
+  params: URLSearchParams;
+  setParams: (params: URLSearchParams) => void;
+} => {
   const [params, setParams] = useSearchParams();
   const paramsRef = React.useRef(params.toString());
   const [state, setState] = React.useState<Partial<TableState>>(
     urlParams2Status(omitUrlSearchParams(params, omitKeys)),
   );
 
-  const handleState = React.useCallback((_state: Partial<TableState>) => {
+  const handleState = React.useCallback((_state: Partial<TableState>, type: keyof TableState) => {
+    if (type === 'columnFilters') {
+      set(_state, 'pagination.pageIndex', 0);
+    }
     const newParams = status2UrlParams(_state, pickUrlSearchParams(paramsRef.current, omitKeys));
     setState(_state);
     paramsRef.current = newParams.toString();


### PR DESCRIPTION
… 

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
### What this PR does / why we need it
feat: enhance useUrlSearchParamsStatus hook with reset pageIndex when columnFilters has changed
### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/project/issues/5429

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
none
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
