### PR TITLE
fix: the description of the role uses data from the API

### DIFF
--- a/packages/shared/src/stores/role.ts
+++ b/packages/shared/src/stores/role.ts
@@ -6,13 +6,13 @@
 import { get, isEmpty } from 'lodash';
 
 import { useUrl } from '../hooks';
-import { getOriginData, parser, getRoleBaseInfo, request } from '../utils';
-import type { PathParams, FormattedRole, OriginalRole, RoleKind } from '../types';
+import { getOriginData, parser, getBaseInfo, request } from '../utils';
+import type { PathParams, FormattedRole, OriginalRole } from '../types';
 import baseStore from './store';
 
-function mapper(item: OriginalRole, kind: RoleKind): FormattedRole {
+function mapper(item: OriginalRole): FormattedRole {
   return {
-    ...getRoleBaseInfo<OriginalRole>(item, kind),
+    ...getBaseInfo<OriginalRole>(item),
     labels: get(item, 'metadata.labels', {}) as FormattedRole['labels'],
     namespace: get(item, 'metadata.namespace'),
     annotations: get(item, 'metadata.annotations', {}) as FormattedRole['annotations'],
@@ -27,6 +27,7 @@ function mapper(item: OriginalRole, kind: RoleKind): FormattedRole {
 }
 
 const store = (module = 'roles') => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { getPath } = useUrl({ module });
 
   const apiVersion = 'kapis/iam.kubesphere.io/v1beta1';
@@ -78,12 +79,12 @@ const store = (module = 'roles') => {
           }`,
       },
     });
-    return res?.items?.map((item: OriginalRole) => mapper(item, `${tempModule}roles`));
+    return res?.items?.map((item: OriginalRole) => mapper(item));
   };
 
   const BaseStore = baseStore<FormattedRole>({
     module,
-    mapper: (item: OriginalRole) => mapper(item, module),
+    mapper: (item: OriginalRole) => mapper(item),
     getResourceUrlFn,
     getListUrlFn: getResourceUrlFn,
   });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links https://github.com/kubesphere/project/issues/5405

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
