### PR TITLE
fix(app): add version name ordering in app version lists

### DIFF
--- a/packages/shared/src/components/Apps/AppForms/AppBaseInfoForm/BasicInfoForm/index.tsx
+++ b/packages/shared/src/components/Apps/AppForms/AppBaseInfoForm/BasicInfoForm/index.tsx
@@ -45,7 +45,10 @@ export function BasicInfoForm({
 }: Props): JSX.Element {
   const { workspace } = useParams();
   const [initData, setInitData] = useState<Partial<AppBasicInfoFormData>>();
-  const { data: versions } = useAppVersionList({ appName }, { status: versionStatus });
+  const { data: versions } = useAppVersionList(
+    { appName },
+    { status: versionStatus, order: 'versionName' },
+  );
   const sortedVersions = useMemo(
     () =>
       (versions || [])

--- a/packages/shared/src/components/Apps/AppVersionSelector/index.tsx
+++ b/packages/shared/src/components/Apps/AppVersionSelector/index.tsx
@@ -28,10 +28,15 @@ export function AppVersionSelector({
   selectedVersionChange,
 }: Props): JSX.Element {
   const [selectedVersion, setSelectedVersion] = useState<string>('');
-  const { data: versions = [] } = useAppVersionList({
-    workspace,
-    appName: appDetail.metadata.name,
-  });
+  const { data: versions = [] } = useAppVersionList(
+    {
+      workspace,
+      appName: appDetail.metadata.name,
+    },
+    {
+      order: 'versionName',
+    },
+  );
   const versionOptions = useMemo(() => {
     return versions?.map(({ metadata, spec }) => ({
       label: spec.versionName,


### PR DESCRIPTION
Add 'versionName' ordering parameter to useAppVersionList hook calls in BasicInfoForm and AppVersionSelector components to ensure consistent version display order

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/kubesphere/issues/6343

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
none
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
