### PR TITLE
fix: Fix the edit manager permission on create workspace

### DIFF
--- a/packages/console/src/pages/workspaces/components/WorkspaceBasicInfoForm/WorkspaceBasicInfoForm.styles.ts
+++ b/packages/console/src/pages/workspaces/components/WorkspaceBasicInfoForm/WorkspaceBasicInfoForm.styles.ts
@@ -15,5 +15,12 @@ export const StyledForm = styled(Form)`
       width: 100%;
       max-width: 455px;
     }
+    .kubed-select-disabled {
+      cursor: not-allowed;
+      .kubed-select-selector {
+        background-color: #eff4f9;
+        border-color: #abb4be;
+      }
+    }
   }
 `;

--- a/packages/console/src/pages/workspaces/components/WorkspaceBasicInfoForm/WorkspaceManagerField.tsx
+++ b/packages/console/src/pages/workspaces/components/WorkspaceBasicInfoForm/WorkspaceManagerField.tsx
@@ -8,7 +8,7 @@ import type { UIEvent } from 'react';
 import { debounce } from 'lodash';
 import { FormItem, Input, Select } from '@kubed/components';
 
-import { userStore } from '@ks-console/shared';
+import { hasPermission, userStore } from '@ks-console/shared';
 
 const { useInfiniteUserList } = userStore;
 
@@ -21,6 +21,11 @@ function WorkspaceManagerField({ manager, setManagerName }: WorkspaceManagerFiel
   const [requestParams, setRequestParams] = useState({
     name: '',
     annotation: 'kubesphere.io/creator',
+  });
+
+  const canEditManager = hasPermission({
+    module: 'workspaces',
+    action: 'manage',
   });
 
   const { data = [], fetchNextPage: nextPage, hasNextPage } = useInfiniteUserList(requestParams);
@@ -72,6 +77,7 @@ function WorkspaceManagerField({ manager, setManagerName }: WorkspaceManagerFiel
           options={options}
           onPopupScroll={debounce(onScroll, 500)}
           onSearch={onSearch}
+          disabled={!canEditManager}
           onSelect={handleSelect}
         />
       </FormItem>


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #https://github.com/kubesphere/project/issues/5061

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
