### PR TITLE
fix: Add ownerReference query to podCards

### DIFF
--- a/packages/shared/src/components/PodsCard/utils.ts
+++ b/packages/shared/src/components/PodsCard/utils.ts
@@ -14,6 +14,7 @@ export interface ParamsType {
   nodeName?: string;
   labelSelector?: string;
   ownerKind?: string;
+  ownerReference?: string;
 }
 
 // TODO: type
@@ -24,9 +25,8 @@ export const getParams = (
   isFederated?: boolean,
 ): ParamsType => {
   const curDetail = isFederated ? details[cluster] : detail;
-  const { name, namespace, kind: curKind, selector } = curDetail || {};
+  const { name, namespace, kind: curKind, selector, uid } = curDetail || {};
   const kind = curKind || get(curDetail._originData, 'kind', '');
-
   let result: ParamsType = {};
 
   if (cluster) {
@@ -53,6 +53,7 @@ export const getParams = (
       break;
     default:
       result.ownerKind = kind === 'Deployment' ? 'ReplicaSet' : kind;
+      result.ownerReference = uid;
       result.labelSelector = joinSelector(selector);
   }
 

--- a/packages/shared/src/stores/pod.ts
+++ b/packages/shared/src/stores/pod.ts
@@ -300,49 +300,22 @@ type UsePodsList = {
 };
 
 export function usePodsList({ params, queryOptions, webSocketOptions }: UsePodsList) {
-  const { message } = useWatchPodsList({
-    url: webSocketOptions.url,
-  });
-
   const { formattedPods, reFetch, page, pageSize, total, prevPage, nextPage, isLoading, refresh } =
     usePodsListQuery(params, queryOptions);
 
-  const data = useMemo(() => {
-    if (message?.object?.kind === 'Pod') {
-      const result = {
-        cluster: params.cluster,
-        ...formatPod(message.object),
-      };
+  useWatchPodsList({
+    url: webSocketOptions.url,
+    onMessage: message => {
+      console.log(message, 'message');
 
-      if (result.uid) {
-        const index = formattedPods.findIndex(
-          item => item.uid === result.uid || item.name === result.name,
-        );
-
-        switch (message.type) {
-          case 'MODIFIED':
-            if (index >= 0) {
-              formattedPods[index] = result;
-            }
-            break;
-          case 'ADDED':
-            if (index < 0) {
-              formattedPods.splice(0, 0, result);
-            }
-            break;
-          case 'DELETED':
-            if (index >= 0) {
-              formattedPods.splice(index, 1);
-            }
-        }
+      if (message?.kind === 'Pod') {
+        refresh();
       }
-    }
-
-    return [...formattedPods];
-  }, [message, formattedPods]);
+    },
+  });
 
   return {
-    data,
+    data: formattedPods,
     page,
     pageSize,
     total,

--- a/packages/shared/src/stores/pod.ts
+++ b/packages/shared/src/stores/pod.ts
@@ -306,8 +306,6 @@ export function usePodsList({ params, queryOptions, webSocketOptions }: UsePodsL
   useWatchPodsList({
     url: webSocketOptions.url,
     onMessage: message => {
-      console.log(message, 'message');
-
       if (message?.kind === 'Pod') {
         refresh();
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?


Add one of the following kinds:
/kind bug
<!--
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #
https://github.com/kubesphere/kubesphere/issues/6369

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
