### PR TITLE
fix: update username field handling in login confirmation

### DIFF
--- a/packages/core/src/containers/Session/LoginConfirm/index.tsx
+++ b/packages/core/src/containers/Session/LoginConfirm/index.tsx
@@ -75,14 +75,14 @@ const LoginConfirm = () => {
             label={t('Username')}
             name="username"
             help={t('USERNAME_DESC')}
-            defaultValue={get(globals, 'user.username')}
+            initialValue={get(globals, 'user.username')}
             rules={[
               { required: true, message: t('PLEASE_INPUT_USERNAME') },
               { pattern: Pattern.PATTERN_USER_NAME, message: t('USERNAME_INVALID') },
               { validator: nameValidator, message: t('USERNAME_EXISTS') },
             ]}
           >
-            <Input name="username" placeholder="user@example.com" maxLength={32} />
+            <Input name="username" placeholder="username" maxLength={32} />
           </FormItem>
           <LoginButton>
             <Button color="secondary" block shadow radius="xl" loading={loginMutation.isLoading}>

--- a/server/services/session.js
+++ b/server/services/session.js
@@ -36,7 +36,7 @@ const handleLoginResp = (resp = {}) => {
   const { username, extra, groups } = jwtDecode(token);
   const email = get(extra, 'email[0]');
   const initialized = get(extra, 'uninitialized[0]') !== 'true';
-  const extraname = get(extra, 'username[0]') || get(extra, 'uid[0]');
+  const extraname = get(extra, 'username[0]');
 
   return {
     username,


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links https://github.com/kubesphere/kubesphere/issues/6394

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
