### PR TITLE
feat: add customizable text for create button in DataTable component

### DIFF
--- a/packages/shared/src/components/DataTable/TableEmpty/CreateButton.tsx
+++ b/packages/shared/src/components/DataTable/TableEmpty/CreateButton.tsx
@@ -4,18 +4,25 @@
  */
 
 import React from 'react';
-import type { ReactElement, MouseEvent } from 'react';
+import type { ReactNode, ReactElement, MouseEvent } from 'react';
 
 import { StyledButton } from './CreateButton.styles';
 
 export interface CreateButtonProps {
   createButton?: boolean | ReactElement;
+  createButtonText?: ReactNode;
   clickCreateButtonFn?: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-export function CreateButton({ createButton, clickCreateButtonFn }: CreateButtonProps) {
+export function CreateButton({
+  createButton,
+  createButtonText,
+  clickCreateButtonFn,
+}: CreateButtonProps) {
   if (createButton === true) {
-    return <StyledButton onClick={clickCreateButtonFn}>{t('CREATE')}</StyledButton>;
+    return (
+      <StyledButton onClick={clickCreateButtonFn}>{createButtonText ?? t('CREATE')}</StyledButton>
+    );
   }
 
   if (!createButton) {

--- a/packages/shared/src/components/DataTable/TableEmpty/index.tsx
+++ b/packages/shared/src/components/DataTable/TableEmpty/index.tsx
@@ -15,6 +15,7 @@ export type TableEmptyProps = PropsWithChildren<EmptyProps & CreateButtonProps>;
 
 export function TableEmpty({
   createButton,
+  createButtonText,
   clickCreateButtonFn,
   children,
   ...emptyProps
@@ -23,7 +24,11 @@ export function TableEmpty({
     <StyledEmpty {...emptyProps}>
       {createButton && (
         <ButtonWrapper>
-          <CreateButton createButton={createButton} clickCreateButtonFn={clickCreateButtonFn} />
+          <CreateButton
+            createButton={createButton}
+            createButtonText={createButtonText}
+            clickCreateButtonFn={clickCreateButtonFn}
+          />
         </ButtonWrapper>
       )}
       {children}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
