### PR TITLE
refactor: implement default page size and improve pagination handling in extensions query

### DIFF
--- a/packages/core/src/containers/Extensions/Management/components/Extensions/Extensions.tsx
+++ b/packages/core/src/containers/Extensions/Management/components/Extensions/Extensions.tsx
@@ -22,6 +22,7 @@ import { useMarketplaceConfigQuery } from '../../../../../stores/marketplace';
 import { getExtensionsEmptyProps as getExtensionsEmptyPropsWithFilters } from '../../../components/ExtensionsEmpty';
 import {
   DEBOUNCE_WAIT,
+  DEFAULT_PAGE_SIZE,
   InstallModalActionType,
   EXTENSIONS_EVALUATION_PAGE_LINK,
 } from '../../constants';
@@ -71,11 +72,11 @@ export function Extensions() {
   const hasFilters = Boolean(queryParams.q ?? queryParams.status ?? queryParams.enabled);
   const {
     isFetching: isExtensionsQueryFetching,
-    totalCount,
+    totalItemCount,
     formattedExtensions,
     refetch: refetchExtensions,
   } = useKExtensionsQuery({
-    params: { isAvailable: true, ...queryParams },
+    params: { isAvailable: true, limit: DEFAULT_PAGE_SIZE, ...queryParams },
     onSuccess: data => {
       const innerLocalExtensionStatusItems = data.map(({ name, statusState, statusConditions }) => {
         const localExtensionsStatus = getLocalExtensionStatusItem({
@@ -318,7 +319,7 @@ export function Extensions() {
     columns,
     loading: isExtensionsQueryFetching,
     data: tableData,
-    rowCount: totalCount,
+    rowCount: totalItemCount,
     state,
     // autoResetPageIndex: true,
     meta: {

--- a/packages/core/src/containers/Extensions/Management/constants/index.ts
+++ b/packages/core/src/containers/Extensions/Management/constants/index.ts
@@ -5,6 +5,8 @@
 
 export const DEBOUNCE_WAIT = 1000;
 
+export const DEFAULT_PAGE_SIZE = 10;
+
 export enum InstallModalActionType {
   ExtensionInstall = 'extension.install',
   ExtensionUpdate = 'extension.update',

--- a/packages/core/src/stores/extension.ts
+++ b/packages/core/src/stores/extension.ts
@@ -14,6 +14,7 @@ import {
   getBaseInfo,
   getOriginData,
   request,
+  requestHelper,
   useWebSocket,
   podStore,
   safeAtob,
@@ -502,20 +503,14 @@ function useKExtensionsQuery(options?: UseKExtensionsQueryOptions) {
   const page = options?.params?.page ?? 1;
   const result = useBaseExtensionsQuery({ url, getRequestParams, ...options });
 
-  const remainingItemCount = result.data?.metadata?.remainingItemCount ?? 0;
-  const currentPageCount = result.formattedExtensions.length;
+  const { totalItemCount } = requestHelper.getPaginationInfo({
+    limit,
+    page,
+    remainingItemCount: result.data?.metadata?.remainingItemCount,
+    currentPageData: result.formattedExtensions,
+  });
 
-  let [totalCount, pageCount] = [0, 0];
-
-  if (limit === undefined || limit === -1) {
-    totalCount = currentPageCount;
-    pageCount = 1;
-  } else {
-    totalCount = limit * (page - 1) + currentPageCount + remainingItemCount;
-    pageCount = Math.ceil(totalCount / limit);
-  }
-
-  return { totalCount, pageCount, ...result };
+  return { totalItemCount, ...result };
 }
 
 interface UseExtensionQueryOptions {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

### What this PR does / why we need it

Fix the issue of the extension center not being able to paginate for the first time.

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links (https://github.com/kubesphere/project/issues/5638)

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
