### PR TITLE
refactor: replace ExtensionStatusState enum with EXTENSION_STATUS_STATE_MAP for improved consistency and readability

### DIFF
--- a/packages/core/src/constants/extension.ts
+++ b/packages/core/src/constants/extension.ts
@@ -65,16 +65,21 @@ const EXTENSIONS_PAGE_PATHS = {
   },
 };
 
-enum ExtensionStatusState {
-  Preparing = 'Preparing',
-  Installing = 'Installing',
-  Upgrading = 'Upgrading',
-  Uninstalling = 'Uninstalling',
-  Installed = 'Installed',
-  Uninstalled = 'Uninstalled',
-  InstallFailed = 'InstallFailed',
-  UpgradeFailed = 'UpgradeFailed',
-  UninstallFailed = 'UninstallFailed',
-}
+const EXTENSION_STATUS_STATE_MAP = {
+  preparing: 'Preparing',
+  installing: 'Installing',
+  upgrading: 'Upgrading',
+  uninstalling: 'Uninstalling',
+  installed: 'Installed',
+  uninstalled: 'Uninstalled',
+  installFailed: 'InstallFailed',
+  upgradeFailed: 'UpgradeFailed',
+  uninstallFailed: 'UninstallFailed',
+} as const;
 
-export { EMPTY_ORIGINAL_EXTENSION, DEFAULT_LANGUAGE, EXTENSIONS_PAGE_PATHS, ExtensionStatusState };
+export {
+  EMPTY_ORIGINAL_EXTENSION,
+  DEFAULT_LANGUAGE,
+  EXTENSIONS_PAGE_PATHS,
+  EXTENSION_STATUS_STATE_MAP,
+};

--- a/packages/core/src/containers/Extensions/Management/actions/index.ts
+++ b/packages/core/src/containers/Extensions/Management/actions/index.ts
@@ -8,7 +8,7 @@ import { debounce } from 'lodash';
 import { notify } from '@kubed/components';
 
 import type {
-  ExtensionStatusState as ExtensionStatusStateType,
+  ExtensionStatusState,
   OriginalInstallPlan,
   OriginalInstallPlanClusterSchedulingPlacement,
   FormattedInstallPlanClusterSchedulingOverrides,
@@ -16,7 +16,7 @@ import type {
   DeleteInstallPlanMutationVariables,
 } from '../../../../types/extension';
 import type { FormattedExtension } from '../../../../stores/extension';
-import { ExtensionStatusState } from '../../../../constants/extension';
+import { EXTENSION_STATUS_STATE_MAP } from '../../../../constants/extension';
 import { DEBOUNCE_WAIT } from '../constants';
 
 const debouncedNotifySuccess = debounce(notify.success, DEBOUNCE_WAIT);
@@ -149,11 +149,11 @@ export const forceDeleteInstallPlan = deleteInstallPlan;
 
 interface HandleInstalledOptions {
   localeDisplayName: string;
-  statusState?: ExtensionStatusStateType;
+  statusState?: ExtensionStatusState;
 }
 
 export function handleInstalled({ localeDisplayName, statusState }: HandleInstalledOptions) {
-  if (statusState === ExtensionStatusState.Installed) {
+  if (statusState === EXTENSION_STATUS_STATE_MAP.installed) {
     debouncedNotifySuccess(
       t('EXTENSION_INSTALLED', { extensionLocaleDisplayName: localeDisplayName }),
     );
@@ -163,7 +163,7 @@ export function handleInstalled({ localeDisplayName, statusState }: HandleInstal
 type HandleUninstalledOptions = HandleInstalledOptions;
 
 export function handleUninstalled({ localeDisplayName, statusState }: HandleUninstalledOptions) {
-  if (statusState === ExtensionStatusState.Uninstalled) {
+  if (statusState === EXTENSION_STATUS_STATE_MAP.uninstalled) {
     debouncedNotifySuccess(
       t('EXTENSION_UNINSTALLED', { extensionLocaleDisplayName: localeDisplayName }),
     );

--- a/packages/core/src/stores/extension.ts
+++ b/packages/core/src/stores/extension.ts
@@ -25,7 +25,7 @@ import type {
   OriginalCategoryList,
   FetchExtensionsRequestParams,
   FetchKExtensionsRequestParams,
-  ExtensionStatusState as ExtensionStatusStateType,
+  ExtensionStatusState,
   ExtensionStatusCondition,
   OriginalExtension,
   OriginalExtensionList,
@@ -41,7 +41,7 @@ import type {
   DeleteInstallPlanMutationVariables,
 } from '../types/extension';
 import { PodStatusPhase } from '../constants/pod';
-import { ExtensionStatusState } from '../constants/extension';
+import { EXTENSION_STATUS_STATE_MAP } from '../constants/extension';
 import { getLocaleValue } from '../utils/extension';
 import { useClustersQuery } from './cluster';
 
@@ -100,16 +100,16 @@ function useCategoriesQuery(options?: UseCategoriesQueryOptions) {
   };
 }
 
-function formatStatusState({ statusState }: { statusState: ExtensionStatusStateType | undefined }) {
-  const isPreparing = statusState === ExtensionStatusState.Preparing;
-  const isInstalling = statusState === ExtensionStatusState.Installing;
-  const isUpgrading = statusState === ExtensionStatusState.Upgrading;
-  const isUninstalling = statusState === ExtensionStatusState.Uninstalling;
-  const isInstalled = statusState === ExtensionStatusState.Installed;
-  const isUninstalled = !statusState || statusState === ExtensionStatusState.Uninstalled;
-  const isInstallFailed = statusState === ExtensionStatusState.InstallFailed;
-  const isUpgradeFailed = statusState === ExtensionStatusState.UpgradeFailed;
-  const isUninstallFailed = statusState === ExtensionStatusState.UninstallFailed;
+function formatStatusState({ statusState }: { statusState: ExtensionStatusState | undefined }) {
+  const isPreparing = statusState === EXTENSION_STATUS_STATE_MAP.preparing;
+  const isInstalling = statusState === EXTENSION_STATUS_STATE_MAP.installing;
+  const isUpgrading = statusState === EXTENSION_STATUS_STATE_MAP.upgrading;
+  const isUninstalling = statusState === EXTENSION_STATUS_STATE_MAP.uninstalling;
+  const isInstalled = statusState === EXTENSION_STATUS_STATE_MAP.installed;
+  const isUninstalled = !statusState || statusState === EXTENSION_STATUS_STATE_MAP.uninstalled;
+  const isInstallFailed = statusState === EXTENSION_STATUS_STATE_MAP.installFailed;
+  const isUpgradeFailed = statusState === EXTENSION_STATUS_STATE_MAP.upgradeFailed;
+  const isUninstallFailed = statusState === EXTENSION_STATUS_STATE_MAP.uninstallFailed;
 
   const isResetLocalExtensionStatusByInstallOrUpgrade =
     isPreparing || isInstalling || isUpgrading || isInstalled || isInstallFailed || isUpgradeFailed;
@@ -177,7 +177,7 @@ function formatExtensionInstallStatus({
   statusState,
   statusConditions,
 }: {
-  statusState: ExtensionStatusStateType | undefined;
+  statusState: ExtensionStatusState | undefined;
   statusConditions: ExtensionStatusCondition[] | undefined;
 }) {
   const formattedStatusState = formatStatusState({ statusState });
@@ -204,7 +204,7 @@ function formatStatusEnabled({
   statusState,
   statusEnabled,
 }: {
-  statusState: ExtensionStatusStateType | undefined;
+  statusState: ExtensionStatusState | undefined;
   statusEnabled: boolean | undefined;
 }) {
   const { isInstalled } = formatStatusState({ statusState });


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

- Updated the extension status handling in core constants and related files to use a constant map instead of an enum.
- Adjusted imports and references in the management actions and stores to align with the new structure.

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
