### PR TITLE
refactor: rename and enhance UI state utility functions for clarity and consistency

### DIFF
--- a/packages/shared/src/utils/uiState.ts
+++ b/packages/shared/src/utils/uiState.ts
@@ -3,9 +3,9 @@
  * https://github.com/kubesphere/console/blob/master/LICENSE
  */
 
-type Value = boolean | undefined | (() => boolean | undefined);
+type ResolvableBoolean = boolean | undefined | (() => boolean | undefined);
 
-function resolveValue(value: Value) {
+function resolveBoolean(value: ResolvableBoolean) {
   if (typeof value === 'function') {
     return Boolean(value());
   }
@@ -14,42 +14,38 @@ function resolveValue(value: Value) {
 }
 
 interface UIState {
-  isShown?: Value;
-  isHidden?: Value;
-  isEnabled?: Value;
-  isDisabled?: Value;
-  isReadOnly?: Value;
-  isLoading?: Value;
+  isVisible?: ResolvableBoolean;
+  isShown?: ResolvableBoolean;
+  isHidden?: ResolvableBoolean;
+  isEnabled?: ResolvableBoolean;
+  isDisabled?: ResolvableBoolean;
+  isReadOnly?: ResolvableBoolean;
+  isLoading?: ResolvableBoolean;
 
   [key: string]: any;
 }
 
-function shouldDisplay(state: UIState) {
-  const isShown = resolveValue(state.isShown);
-  const isHidden = resolveValue(state.isHidden);
+function resolveVisibilityState(state: UIState) {
+  const isVisible = resolveBoolean(state.isVisible) || resolveBoolean(state.isShown);
+  const isHidden = resolveBoolean(state.isHidden);
+  const isFinalVisible = isVisible && !isHidden;
+  const isFinalHidden = !isFinalVisible;
 
-  return isShown && !isHidden;
+  return { isVisible: isFinalVisible, isHidden: isFinalHidden };
 }
 
-function getDisabledState(state: UIState) {
-  const isEnabled = resolveValue(state.isEnabled);
-  const isDisabled = resolveValue(state.isDisabled);
-  const isReadOnly = resolveValue(state.isReadOnly);
-  const isLoading = resolveValue(state.isLoading);
+function resolveEnabledState(state: UIState) {
+  const isEnabled = resolveBoolean(state.isEnabled);
+  const isDisabled = resolveBoolean(state.isDisabled);
+  const isReadOnly = resolveBoolean(state.isReadOnly);
+  const isLoading = resolveBoolean(state.isLoading);
 
-  if (isDisabled) {
-    return { isEnabled: false, isDisabled: true };
-  }
+  const isCalculatedDisabled = isDisabled || isReadOnly || isLoading;
 
-  if (isReadOnly) {
-    return { isEnabled: false, isDisabled: true };
-  }
+  const isFinalEnabled = isEnabled && !isCalculatedDisabled;
+  const isFinalDisabled = !isFinalEnabled;
 
-  if (isLoading) {
-    return { isEnabled: false, isDisabled: true };
-  }
-
-  return { isEnabled, isDisabled: !isEnabled };
+  return { isEnabled: isFinalEnabled, isDisabled: isFinalDisabled };
 }
 
-export { shouldDisplay, getDisabledState };
+export { resolveVisibilityState, resolveEnabledState };

--- a/packages/shared/src/utils/uiState.ts
+++ b/packages/shared/src/utils/uiState.ts
@@ -21,11 +21,9 @@ interface UIState {
   isDisabled?: ResolvableBoolean;
   isReadOnly?: ResolvableBoolean;
   isLoading?: ResolvableBoolean;
-
-  [key: string]: unknown;
 }
 
-function resolveVisibilityState(state: UIState) {
+function resolveVisibilityState<T extends UIState>(state: T) {
   const isVisible = resolveBoolean(state.isVisible) || resolveBoolean(state.isShown);
   const isHidden = resolveBoolean(state.isHidden);
   const isFinalVisible = isVisible && !isHidden;
@@ -34,7 +32,7 @@ function resolveVisibilityState(state: UIState) {
   return { isVisible: isFinalVisible, isHidden: isFinalHidden };
 }
 
-function resolveEnabledState(state: UIState) {
+function resolveEnabledState<T extends UIState>(state: T) {
   const isEnabled = resolveBoolean(state.isEnabled);
   const isDisabled = resolveBoolean(state.isDisabled);
   const isReadOnly = resolveBoolean(state.isReadOnly);
@@ -48,4 +46,5 @@ function resolveEnabledState(state: UIState) {
   return { isEnabled: isFinalEnabled, isDisabled: isFinalDisabled };
 }
 
+export type { UIState };
 export { resolveVisibilityState, resolveEnabledState };

--- a/packages/shared/src/utils/uiState.ts
+++ b/packages/shared/src/utils/uiState.ts
@@ -22,7 +22,7 @@ interface UIState {
   isReadOnly?: ResolvableBoolean;
   isLoading?: ResolvableBoolean;
 
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 function resolveVisibilityState(state: UIState) {

--- a/packages/shared/src/utils/uiState.ts
+++ b/packages/shared/src/utils/uiState.ts
@@ -47,4 +47,5 @@ function resolveEnabledState<T extends UIState>(state: T) {
 }
 
 export type { UIState };
+
 export { resolveVisibilityState, resolveEnabledState };


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

- Renamed `Value` type to `ResolvableBoolean` for better understanding of its purpose.
- Updated `resolveValue` to `resolveBoolean` for improved clarity in function naming.
- Refactored `UIState` interface to use `ResolvableBoolean` for all boolean properties.
- Renamed `shouldDisplay` to `resolveVisibilityState` and adjusted its logic to return visibility and hidden states.
- Renamed `getDisabledState` to `resolveEnabledState` and streamlined the logic for determining enabled and disabled states.

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
