### PR TITLE
feat: export Button component from Base index for improved accessibility

### DIFF
--- a/packages/shared/src/components/Base/Button/Copy/index.tsx
+++ b/packages/shared/src/components/Base/Button/Copy/index.tsx
@@ -1,0 +1,73 @@
+/*
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/console/blob/master/LICENSE
+ */
+
+import React, { useState, useCallback } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { useHover } from 'react-use';
+
+import type { ButtonProps } from '@kubed/components';
+import { Tooltip } from '@kubed/components';
+import type { Props as IconProps } from '@kubed/icons';
+import { CopyDuotone } from '@kubed/icons';
+
+import { copyToClipboard } from '../../../../utils/dom';
+
+import { StyledButton, Content } from './styles';
+
+export interface CopyButtonProps extends ButtonProps {
+  value: string;
+  label?: ReactNode;
+  timeout?: number;
+  iconProps?: IconProps & { hoverVariant?: IconProps['variant'] };
+
+  styles?: {
+    icon?: CSSProperties;
+  };
+  hoverStyles?: {
+    icon?: CSSProperties;
+  };
+}
+
+export function CopyButton({
+  value,
+  label,
+  timeout = 1500,
+  iconProps,
+  styles,
+  hoverStyles,
+  ...buttonProps
+}: CopyButtonProps) {
+  const [isCopied, setIsCopied] = useState(false);
+
+  const handleClick = useCallback(() => {
+    copyToClipboard(value);
+    setIsCopied(true);
+    setTimeout(() => {
+      setIsCopied(false);
+    }, timeout);
+  }, [value, timeout]);
+
+  const [element] = useHover(state => (
+    <Content>
+      <CopyDuotone
+        size={16}
+        variant={state ? iconProps?.hoverVariant : iconProps?.variant}
+        style={state ? hoverStyles?.icon : styles?.icon}
+      />
+      {label && <div>{label}</div>}
+    </Content>
+  ));
+
+  return (
+    <Tooltip
+      content={isCopied ? t('SHARED.COPY_BUTTON.CLICK') : t('SHARED.COPY_BUTTON.HOVER')}
+      hideOnClick={false}
+    >
+      <StyledButton variant="link" onClick={handleClick} {...buttonProps}>
+        {element}
+      </StyledButton>
+    </Tooltip>
+  );
+}

--- a/packages/shared/src/components/Base/Button/Copy/styles.ts
+++ b/packages/shared/src/components/Base/Button/Copy/styles.ts
@@ -1,0 +1,23 @@
+/*
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/console/blob/master/LICENSE
+ */
+
+import styled from 'styled-components';
+
+import { Button } from '@kubed/components';
+
+export const StyledButton = styled(Button)`
+  height: 16px;
+  border: 0;
+
+  &:active {
+    opacity: 0.7;
+  }
+`;
+
+export const Content = styled.div`
+  display: flex;
+  align-items: center;
+  column-gap: 6px;
+`;

--- a/packages/shared/src/components/Base/Button/index.ts
+++ b/packages/shared/src/components/Base/Button/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Please refer to the LICENSE file in the root directory of the project.
+ * https://github.com/kubesphere/console/blob/master/LICENSE
+ */
+
+export * from './Copy';

--- a/packages/shared/src/components/Base/index.ts
+++ b/packages/shared/src/components/Base/index.ts
@@ -16,3 +16,4 @@ export { default as ContainerPortsCard } from './Card/Ports';
 export { default as StatusCircle } from './Card/StatusCircle';
 export { default as StatusTabs } from './Card/StatusTabs';
 export * from './Bar';
+export * from './Button';


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it

### Which issue(s) this PR fixes

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Links #

### Special notes for reviewers

```

```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs

```
